### PR TITLE
Ml datagen

### DIFF
--- a/src/app/core/model/draft.ts
+++ b/src/app/core/model/draft.ts
@@ -969,7 +969,7 @@ export class Draft{
    * @param i: the tieups array, j: the treadling array, the threading array
    * @returns (nothing) in the future - this can return the specific points to update on the draft
    */  
-  recalculateDraft(tieup, treadling, threading) {
+  recalculateDraft(tieup: Array<Array<boolean>>, treadling: Array<number>, threading: Array<number>) {
     for (var i = 0; i < treadling.length;i++) {
       var active_treadle = treadling[i];
       if (active_treadle != -1) {

--- a/src/app/core/topbar/topbar.component.html
+++ b/src/app/core/topbar/topbar.component.html
@@ -19,10 +19,8 @@
   
 <span class="right">
 
-    <button mat-icon-button matTooltip ="print screen">
-      <a class="print-link" #printLink (click)="saveAsPrint($event)" mat-menu-item>
+    <button mat-icon-button matTooltip ="print screen" (click)="saveAsPrint()" >
       <i class="fas fa-print"></i>
-      </a> 
     </button>
 
     
@@ -33,14 +31,14 @@
     <i class="fas fa-download"></i>
   </button> 
     <mat-menu #downloadDropdown mat-raised-button>
-      <a #adaLink (click)="saveAsAda($event)" mat-menu-item> as AdaCAD file</a>
-      <a #bmpLink (click)="saveAsBmp($event)" mat-menu-item> export all visible drafts as bitmaps</a>
-      <a #wifLink (click)="saveAsWif($event)" mat-menu-item> export all visible drafts as .WIF files</a>
+      <a  (click)="saveAsAda()" mat-menu-item> as AdaCAD workspace file</a>
+      <a  (click)="saveAsBmp()" mat-menu-item> export all visible drafts as bitmaps</a>
+      <a  (click)="saveAsWif()" mat-menu-item> export all visible drafts as .WIF files</a>
     </mat-menu>
 
 
      <button mat-icon-button="Open" 
-     matTooltip ="open or start a new draft"
+     matTooltip ="open a new workspace"
      (click)="openNewFileDialog(null)">
      <i class="fas fa-folder-open"></i>
     </button>

--- a/src/app/core/topbar/topbar.component.html
+++ b/src/app/core/topbar/topbar.component.html
@@ -28,15 +28,14 @@
     
   <button mat-icon-button 
   [matMenuTriggerFor]="downloadDropdown"
-  matTooltip ="save current file"
+  matTooltip ="export adacad workspace"
   >
     <i class="fas fa-download"></i>
   </button> 
     <mat-menu #downloadDropdown mat-raised-button>
-
-      <a #bmpLink (click)="saveAsBmp($event)" mat-menu-item> as Bitmap</a>
       <a #adaLink (click)="saveAsAda($event)" mat-menu-item> as AdaCAD file</a>
-      <a #wifLink (click)="saveAsWif($event)" mat-menu-item> as Wif file</a>
+      <a #bmpLink (click)="saveAsBmp($event)" mat-menu-item> export all visible drafts as bitmaps</a>
+      <a #wifLink (click)="saveAsWif($event)" mat-menu-item> export all visible drafts as .WIF files</a>
     </mat-menu>
 
 

--- a/src/app/core/topbar/topbar.component.ts
+++ b/src/app/core/topbar/topbar.component.ts
@@ -28,17 +28,6 @@ export class TopbarComponent implements OnInit {
   @Input() loomtypes;
   @Input() density_units;
   @Input() source; 
-  
-  @ViewChild('bmpLink', {static: true}) bmpLink: any;
-  @ViewChild('adaLink', {static: true}) adaLink: any;
-  @ViewChild('wifLink', {static: true}) wifLink: any;
-  @ViewChild('printLink', {static: true}) printLink: any;
-
-  downloadBmp: ElementRef;
-  downloadAda: ElementRef;
-  downloadWif: ElementRef;
-  downloadPrint: ElementRef;
-
 
   constructor(private dialog: MatDialog) { }
 
@@ -46,18 +35,12 @@ export class TopbarComponent implements OnInit {
   }
 
   ngAfterViewInit() {
-    if(this.source == 'weaver'){
-      this.downloadBmp = this.bmpLink._elementRef;
-      this.downloadWif = this.wifLink._elementRef;
-    }
-    this.downloadAda = this.adaLink._elementRef;
-    this.downloadPrint = this.printLink._elementRef;
+
   }
 
   public saveAsBmp(e: any) {
     var obj: any = {
       name: this.filename,
-      downloadLink: this.downloadBmp,
       type: "bmp"
     }
     console.log(obj);
@@ -67,7 +50,6 @@ export class TopbarComponent implements OnInit {
   public saveAsAda(e: any) {
     var obj: any = {
       name: this.filename,
-      downloadLink: this.downloadAda,
       type: "ada"
     }
     console.log(obj);
@@ -77,17 +59,14 @@ export class TopbarComponent implements OnInit {
   public saveAsWif(e: any) {
     var obj: any = {
       name: this.filename,
-      downloadLink: this.downloadWif,
       type: "wif"
     }
-    console.log(obj);
     this.onSave.emit(obj);
   }
 
   public saveAsPrint(e: any) {
     var obj: any = {
       name: this.filename,
-      downloadLink: this.downloadPrint,
       type: "jpg"
     }
     this.onSave.emit(obj);

--- a/src/app/mixer/mixer.component.ts
+++ b/src/app/mixer/mixer.component.ts
@@ -422,42 +422,28 @@ export class MixerComponent implements OnInit {
    * @param {Event} e - Press Control + x
    * @returns {void}
    */
-  // @HostListener('window:keydown.p', ['$event'])
-  // private keyEventPaste(e) {
-  //   this.onPaste({});
-  // }
 
-
-  // /**
-  //  * this is called when import has been called from the sidebar
-  //  * @param result 
-  //  */
-  // public draftUploaded(result: LoadResponse){
-
-  //   console.log("import", result);
-  //   const data: FileObj = result.data;
-
-  //   data.drafts.forEach().
-
-  //   const draft: Draft = new Draft(result);
-  //   this.palette.addSubdraftFromDraft(draft);
-  // }
 
   /**
    * this is called when a user pushes bring from the topbar
    * @param event 
-   * @todo add interface to select which draft to export if BMP or WIF
    */
-  public onSave(e: any){
+  public async onSave(e: any) : Promise<any>{
 
-    console.log(e);
-    let link = e.downloadLink.nativeElement;
+    const link = document.createElement('a')
+
 
     switch(e.type){
       case 'jpg': 
       link.href = this.fs.saver.jpg(this.palette.getPrintableCanvas(e));
       link.download = e.name + ".jpg";
       this.palette.clearCanvas();
+      link.click();
+
+      break;
+
+      case 'wif': 
+      this.palette.downloadVisibleDraftsAsWif();
       break;
 
       case 'ada': 
@@ -467,7 +453,16 @@ export class MixerComponent implements OnInit {
         [],
         false);
         link.download = e.name + ".ada";
+        link.click();
+      break;
+
+      case 'bmp':
+        this.palette.downloadVisibleDraftsAsBmp();
+      break;
     }
+    return Promise.resolve(null);
+
+
   }
 
   /**

--- a/src/app/mixer/palette/operation/operation.component.html
+++ b/src/app/mixer/palette/operation/operation.component.html
@@ -35,6 +35,7 @@ cdkDrag
     </button> 
     </div>
 
+
     <button 
     matTooltip= "Duplilcate"
     class="button is-small is-primary fa fa-clone"

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -83,6 +83,8 @@ export class OperationComponent implements OnInit {
 
    has_connections_in: boolean = false;
 
+   subdraft_visible: boolean = true;
+
   constructor(
     private operations: OperationService, 
     private dialog: MatDialog,
@@ -266,7 +268,6 @@ export class OperationComponent implements OnInit {
   duplicate(){
     this.duplicateOp.emit({id: this.id});
   }
-
 
 
 

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -340,6 +340,36 @@ export class PaletteComponent implements OnInit{
 
   }
 
+  /**
+   * this cycles through all subdrafts and calls the download call on any subdrafts
+   * who are currently visible. 
+   */
+  downloadVisibleDraftsAsBmp(){
+
+    const drafts: Array<SubdraftComponent> = this.tree.getDrafts();
+    const visible_drafts: Array<SubdraftComponent> = drafts.filter(el => el.draft_visible)
+    const functions: Array<Promise<any>> = visible_drafts.map(el => el.saveAsBmp());
+    Promise.all(functions).then(el =>
+      console.log("Downloaded "+functions.length+" files")
+    );
+
+  }
+  
+  /**
+   * this cycles through all subdrafts and calls the download call on any subdrafts
+   * who are currently visible. 
+   */
+   downloadVisibleDraftsAsWif(){
+
+    const drafts: Array<SubdraftComponent> = this.tree.getDrafts();
+    const visible_drafts: Array<SubdraftComponent> = drafts.filter(el => el.draft_visible)
+    const functions: Array<Promise<any>> = visible_drafts.map(el => el.saveAsWif());
+    Promise.all(functions).then(el =>
+      console.log("Downloaded "+functions.length+" files")
+    );
+
+  }
+  
 
 
   /**

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -683,7 +683,7 @@ export class PaletteComponent implements OnInit{
    */
   removeSubdraft(id: number){
 
-    console.log("removing id", id);
+    console.log("removing subdraft id", id);
 
     const parent_id = this.tree.getSubdraftParent(id);
 
@@ -741,15 +741,12 @@ export class PaletteComponent implements OnInit{
     const ref:ViewRef = this.tree.getViewRef(id);
     const outputs:Array<number> = this.tree.getNonCxnOutputs(id);
 
-    console.log("before remove op")
-    this.tree.print();
-
     outputs.forEach(output => {
       if(this.tree.getType(output) == 'draft'){
         const comp = <SubdraftComponent> this.tree.getComponent(output);
         comp.has_active_connection = false;
         comp.active_connection_order = 0;
-        comp.parent_id = 0;
+        comp.parent_id = -1;
       }
     })
 
@@ -759,25 +756,18 @@ export class PaletteComponent implements OnInit{
 
 
     const old_cxns:Array<number> = this.tree.getUnusuedConnections();
-    console.log("old connections", old_cxns);
     old_cxns.forEach(cxn => {
       const cxn_view_ref = this.tree.getViewRef(cxn);
       this.removeFromViewContainer(cxn_view_ref);
       this.tree.removeNode(cxn);
     });    
 
-    // outputs.forEach(output => {
-    //   this.removeSubdraft(output);
-    // })
 
 
     //calls manually here so that the affected branches can be pinged before the node is deleted 
     this.recalculateDownstreamDrafts(downstream_ops);
     this.removeFromViewContainer(ref);
     this.viewport.removeObj(id);
-
-    console.log("after remove op")
-    this.tree.print();
 
   }
 
@@ -1070,7 +1060,7 @@ export class PaletteComponent implements OnInit{
      }
 
    /**
-   * Deletes the subdraft that called this function.
+   * Duplicates the operation that called this function.
    */
     onDuplicateOpCalled(obj: any){
       console.log("duplicating "+obj.id);
@@ -1094,6 +1084,9 @@ export class PaletteComponent implements OnInit{
       //this.operationParamChanged({id: id});
      // this.addTimelineState();
  }
+
+
+
 
 
      /**

--- a/src/app/mixer/palette/subdraft/subdraft.component.html
+++ b/src/app/mixer/palette/subdraft/subdraft.component.html
@@ -85,10 +85,10 @@
 		
 
 		<mat-menu #downloadDropdown mat-raised-button>
-			<a class="print-link" #printLink (click)="saveAsPrint($event)" mat-menu-item>as Printable Image</a>
-			<a #bmpLink (click)="saveAsBmp($event)" mat-menu-item> as Bitmap</a>
-			<a #adaLink (click)="saveAsAda($event)" mat-menu-item> as AdaCAD file</a>
-			<a #wifLink (click)="saveAsWif($event)" mat-menu-item> as Wif file</a>
+			<a  (click)="saveAsPrint()" mat-menu-item>as Printable Image</a>
+			<a   (click)="saveAsBmp()" mat-menu-item> as Bitmap</a>
+			<a  (click)="saveAsAda()" mat-menu-item> as AdaCAD file</a>
+			<a  (click)="saveAsWif()" mat-menu-item> as Wif file</a>
 		  </mat-menu>
 		
 		  <button *ngIf='parent_id === -1'

--- a/src/app/mixer/palette/subdraft/subdraft.component.html
+++ b/src/app/mixer/palette/subdraft/subdraft.component.html
@@ -14,13 +14,13 @@
 	<div id="scale-{{draft.id}}" class="subdraft-container">
 
 
-  	<div class="subdraft-contents" [class.active-selection] = has_active_selection>
+  	<div  class="subdraft-contents" [class.active-selection] = has_active_selection>
 
 		
-		<canvas id="{{id}}" class="maindraft">  
+		<canvas id="{{id}}" class="maindraft" [class.hidden] = '!draft_visible'>  
 		</canvas>
 
-		<div class="bottom-opts">
+		<div class="bottom-opts" [class.has_draft_hidden]="!draft_visible">
 		
 		<ng-container *ngIf="set_connectable">
 			<button matTooltip = "click here to use this draft as input"
@@ -33,26 +33,41 @@
 			</button>
 		</ng-container>
 
-		<!-- <span>  {{id}} // {{draft.warps}} x {{draft.wefts}}</span> -->
-		<span>{{draft.warps}} x {{draft.wefts}}</span>
+		<div class='dims'>{{draft.warps}} x {{draft.wefts}}</div>
 		
-		
+
+		<button *ngIf='!draft_visible' 
+		matTooltip= "Show/Hide Draft"
+		class="button is-small is-primary"
+		aria-label="Example icon button with a home icon"
+		(click)="showhide()"
+		>
+			<i class="fas fa-eye-slash"></i>		  
+		</button>
+
 		
 	 </div>
 	</div>
 
-	<div class="subdraft-details" [class.hide]="set_connectable"> 
+	<div class="subdraft-details" [class.hide]="set_connectable || !draft_visible"> 
 		<div class ="align-top">
 		
 		<!-- <ng-container *ngIf="parent_id === -1"> -->
 
-	  	<button
+	  	<button *ngIf='parent_id === -1'
 		class="button is-small is-primary fas fa-expand-alt"
 		matTooltip ="edit this draft"
 		(click)="finetune()">
 	   </button>
 
-	
+	   <button *ngIf='parent_id !== -1'
+	   matTooltip= "Show/Hide Draft"
+	   class="button is-small is-primary fas"
+	   [class.fa-eye-slash] = '!draft_visible'
+	   [class.fa-eye] = 'draft_visible'
+	   (click)="showhide()">
+	   </button>
+
 
 		<button 
 		matTooltip= "Duplilcate"
@@ -67,26 +82,25 @@
 		class="button is-small is-primary fas fa-download"
 		 matTooltip ="download this draft">
 		</button>
-
 		
 
-		  <mat-menu #downloadDropdown mat-raised-button>
+		<mat-menu #downloadDropdown mat-raised-button>
 			<a class="print-link" #printLink (click)="saveAsPrint($event)" mat-menu-item>as Printable Image</a>
 			<a #bmpLink (click)="saveAsBmp($event)" mat-menu-item> as Bitmap</a>
 			<a #adaLink (click)="saveAsAda($event)" mat-menu-item> as AdaCAD file</a>
 			<a #wifLink (click)="saveAsWif($event)" mat-menu-item> as Wif file</a>
 		  </mat-menu>
 		
+		  <button *ngIf='parent_id === -1'
+		  matTooltip= "Delete"
+		  class="button is-small is-primary fas fa-times"
+		  [style.color]="button_color" 
+		  [name]="delete"
+		  (click)="designActionChange('delete')">
+		  </button>
+
 		</div>
-		<div class="align-bottom">
-			<button 
-			matTooltip= "Delete"
-			class="button is-small is-primary fas fa-times"
-			[style.color]="button_color" 
-			[name]="delete"
-			(click)="designActionChange('delete')">
-			</button>
-		</div>
+
 
 
 	

--- a/src/app/mixer/palette/subdraft/subdraft.component.html
+++ b/src/app/mixer/palette/subdraft/subdraft.component.html
@@ -33,8 +33,13 @@
 			</button>
 		</ng-container>
 
-		<div class='dims'>{{draft.warps}} x {{draft.wefts}}</div>
+
+		<div class='dims_and_name'>
+			<div>{{draft.warps}} x {{draft.wefts}}</div>
+			<div><input matInput [(ngModel)]="draft.name"></div>
+		</div>
 		
+
 
 		<button *ngIf='!draft_visible' 
 		matTooltip= "Show/Hide Draft"

--- a/src/app/mixer/palette/subdraft/subdraft.component.scss
+++ b/src/app/mixer/palette/subdraft/subdraft.component.scss
@@ -22,7 +22,7 @@
 
 .scale-container{
 
-	position: absolute;
+	position: absoludims_and_namete;
 	top: 0px;
 	left: 0px;
 	color: grey;
@@ -97,7 +97,9 @@ h3{
 	}
 }
 
-.dims{
+.dims_and_name{
+	display: flex;
+	flex-direction: column;
     margin-top: auto;
     font-size: .8em;
 }

--- a/src/app/mixer/palette/subdraft/subdraft.component.scss
+++ b/src/app/mixer/palette/subdraft/subdraft.component.scss
@@ -8,6 +8,18 @@
 	justify-content:flex-end;
 }
 
+.bottom-opts{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.bottom-opts.has_draft_hidden{
+	height: auto;
+	background-color: white;
+	width: 224px;
+}
+
 .scale-container{
 
 	position: absolute;
@@ -85,6 +97,11 @@ h3{
 	}
 }
 
+.dims{
+    margin-top: auto;
+    font-size: .8em;
+}
+
 .mat-icon{
 	height: auto;
 }
@@ -127,6 +144,10 @@ svg{
 	display: block;
 	overflow:hidden;
 	border: thin solid white;
+}
+
+.hidden {
+	display: none;
 }
 
 .no-pointer{

--- a/src/app/mixer/palette/subdraft/subdraft.component.ts
+++ b/src/app/mixer/palette/subdraft/subdraft.component.ts
@@ -103,6 +103,8 @@ export class SubdraftComponent implements OnInit {
 
   modal: MatDialogRef<DraftdetailComponent, any>;
 
+  draft_visible: boolean = true;
+
 
   constructor(private inks: InkService, 
     private layer: LayersService, 
@@ -243,8 +245,6 @@ export class SubdraftComponent implements OnInit {
    * @param pos 
    */
   setPosition(pos: Point){
-
-    console.log("setting position", pos);
     
     this.bounds.topleft = pos;
     this.interlacement =  utilInstance.resolvePointToAbsoluteNdx(pos, this.scale);
@@ -509,6 +509,10 @@ export class SubdraftComponent implements OnInit {
 
   enableDrag(){
     this.disable_drag = false;
+  }
+
+  showhide(){
+    this.draft_visible = !this.draft_visible;
   }
 
   connectionClicked(id:number){

--- a/src/app/mixer/palette/subdraft/subdraft.component.ts
+++ b/src/app/mixer/palette/subdraft/subdraft.component.ts
@@ -69,8 +69,6 @@ export class SubdraftComponent implements OnInit {
    */
   interlacement: Interlacement;
 
-  filename: string = "adacad";
-
   ink = 'neq'; //can be or, and, neq, not, splice
 
   counter:number  =  0; // keeps track of how frequently to call the move functions
@@ -119,7 +117,6 @@ export class SubdraftComponent implements OnInit {
 
     this.bounds.width = this.draft.warps * this.scale;
     this.bounds.height = this.draft.wefts * this.scale;
-    this.filename = this.draft.name;
 
   }
 
@@ -564,7 +561,7 @@ export class SubdraftComponent implements OnInit {
 
     const a = document.createElement('a')
     a.href =  this.fs.saver.bmp(b);
-    a.download = this.filename + "_bitmap.jpg";
+    a.download = this.draft.name + "_bitmap.jpg";
     a.click();
 
     this.drawDraft();
@@ -576,7 +573,7 @@ export class SubdraftComponent implements OnInit {
     async saveAsAda() : Promise<any>{
       const a = document.createElement('a');
       a.href = this.fs.saver.ada('draft', [this.draft], [], false);
-      a.download = this.filename + ".ada";
+      a.download = this.draft.name + ".ada";
       a.click();
 
       return Promise.resolve(null);
@@ -592,7 +589,7 @@ export class SubdraftComponent implements OnInit {
 
       const a = document.createElement('a');
       a.href = this.fs.saver.wif(this.draft, loom);
-      a.download  = this.filename +".wif";
+      a.download  = this.draft.name +".wif";
       a.click();
 
       return Promise.resolve(null);
@@ -616,7 +613,7 @@ export class SubdraftComponent implements OnInit {
 
       const a = document.createElement('a')
       a.href =  this.fs.saver.jpg(b);
-      a.download = this.filename + ".jpg";
+      a.download = this.draft.name + ".jpg";
       a.click();
   
   

--- a/src/app/mixer/provider/tree.service.ts
+++ b/src/app/mixer/provider/tree.service.ts
@@ -231,7 +231,18 @@ export class TreeService {
   }
 
   /**
-   * test if this node has generated many children, as opposed to just one
+   * test if this node has children, as opposed to just zero
+   * @param id 
+   * @returns a boolean 
+   */
+   isParent(id: number):boolean{
+    const tn: TreeNode = this.getTreeNode(id);
+    return (tn.outputs.length > 0);
+  }
+
+
+  /**
+   * test if this node has many children, as opposed to just one
    * @param id 
    * @returns a boolean 
    */
@@ -415,6 +426,7 @@ export class TreeService {
 
   /**
    * updates inputs and outputs of this node and delete this node from the list
+   * returns a list of all the deleted non-connection nodes
    * @param cxn_id 
    */
   private removeNodeTreeAssociations(id:number){


### PR DESCRIPTION
merging features intended to support the bulk creation and download of drafts for uses of training machine learning algorithms. 

Features include: 
1. "variants" function that generates multiple variants of the same draft that are still structurally equivalent
2. download all visible drafts box on tool bar to bulk download drafts. 
3. support for viewing or hiding drafts generated from operations
4. a crop features (for cropping a section within a draft"
5. changed "mirror" to "replicate" to solve confusions that emerged in Mica workshop
6. added support for generating drafts from threading tieup and treadling and/or drawdown. 
7. removed ability to edit drafts that are generated from operations
8. added support for naming individual drafts. 