### PR TITLE
Op extensions

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,17 +2,9 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { WeaverComponent } from './weaver/weaver.component';
 import { MixerComponent } from './mixer/mixer.component';
-import { LoginComponent } from './core/login/login.component';
-import { ProfileComponent } from './core/profile/profile.component';
-import { SignupComponent } from './core/signup/signup.component';
-import { EmailComponent } from './core/email/email.component';
+
 
 const routes: Routes = [
- // { path: '', redirectTo: 'login', pathMatch: 'full' },
-  // { path: 'login', component: LoginComponent },
-  // { path: 'email-login', component: EmailComponent },
-  // { path: 'signup', component: SignupComponent },
-  // { path: 'profile', component: ProfileComponent },
    {
      path: '',
      component: MixerComponent,

--- a/src/app/core/modal/init/init.modal.html
+++ b/src/app/core/modal/init/init.modal.html
@@ -11,9 +11,9 @@
           <mat-label>Where would you like to begin?</mat-label>
         <mat-select [(value)]="selected" (selectionChange)="selectionMade(selected)">
           
-          <mat-option *ngIf="auth.isLoggedIn" value="recover">
+          <!-- <mat-option *ngIf="auth.isLoggedIn" value="recover">
             Recover Previous Workspace
-          </mat-option>
+          </mat-option> -->
           
           <mat-option *ngFor="let opt of opts" [value]="opt.value">
             {{opt.viewValue}}

--- a/src/app/core/modal/init/init.modal.ts
+++ b/src/app/core/modal/init/init.modal.ts
@@ -45,8 +45,8 @@ export class InitModal implements OnInit {
 
 
   constructor(
-    private auth: AuthService,
     private fls: FileService,
+    private auth: AuthService,
     private dm: DesignmodesService, 
     private http: HttpClient,
     private dialogRef: MatDialogRef<InitModal>, 
@@ -91,11 +91,11 @@ export class InitModal implements OnInit {
   
   }
 
-  selectionMade(selection: any){
-    if(selection === 'recover'){
-      this.loadSavedFile();
-    }
-  }
+  // selectionMade(selection: any){
+  //   if(selection === 'recover'){
+  //     this.loadSavedFile();
+  //   }
+  // }
 
   loadExample(filename: string){
     console.log("loading example: ", filename);
@@ -108,28 +108,7 @@ export class InitModal implements OnInit {
     }); 
   }
 
-  loadSavedFile(){
-    this.auth.user.subscribe(user => {
-      if(user !== null){
-
-        const db = fbref(getDatabase());
-
-
-        fbget(child(db, `users/${this.auth.uid}/ada`)).then((snapshot) => {
-          if (snapshot.exists()) {
-            this.fls.loader.ada("recovered draft", snapshot.val()).then(lr => {
-              this.dialogRef.close(lr)
-            });
-          }
-        }).catch((error) => {
-          console.error(error);
-        });
-  
-    }
-  
-});
-
-  }
+ 
 
 
 

--- a/src/app/mixer/mixer.component.html
+++ b/src/app/mixer/mixer.component.html
@@ -7,6 +7,7 @@ source="mixer"
   (onLoadNewFile)="loadNewFile($event);"
   (onClearScreen)="clearAll();"
   (onSave)="onSave($event);">
+
 </app-topbar>
 
 <mat-drawer-container #container class="mat-drawer-container" cdkScrollable>
@@ -97,3 +98,4 @@ source="mixer"
 
 
 </mat-drawer-container>
+

--- a/src/app/mixer/mixer.component.ts
+++ b/src/app/mixer/mixer.component.ts
@@ -161,7 +161,6 @@ export class MixerComponent implements OnInit {
    */
    importNewFile(result: LoadResponse){
     
-    console.log("imported new file", result, result.data);
     this.processFileData(result.data).then(
       this.palette.changeDesignmode('move')
     );
@@ -294,7 +293,6 @@ export class MixerComponent implements OnInit {
         }
       });
 
-      console.log("seed nodes mapped ", seeds);
 
 
       
@@ -312,7 +310,7 @@ export class MixerComponent implements OnInit {
         return this.tree.validateNodes();
     })
     .then(el => {
-      console.log("performing top level ops");
+      //console.log("performing top level ops");
 
        return  this.tree.performTopLevelOps();
     })
@@ -324,7 +322,7 @@ export class MixerComponent implements OnInit {
         if(this.tree.hasParent(el.id)){
           el.draft = new Draft({warps: 1, wefts: 1, pattern: [[new Cell(false)]]});
         } else{
-          console.log("removing node ", el.id, el.type, this.tree.hasParent(el.id));
+       //   console.log("removing node ", el.id, el.type, this.tree.hasParent(el.id));
           this.tree.removeNode(el.id);
         } 
       })
@@ -395,15 +393,20 @@ export class MixerComponent implements OnInit {
       this.auth.user.subscribe(user => {
 
         if(user === null){
+
           const dialogRef = this.dialog.open(InitModal, {
             data: {source: 'mixer'}
           });
+
 
           dialogRef.afterClosed().subscribe(loadResponse => {
             if(loadResponse !== undefined) this.loadNewFile(loadResponse);
       
          });
         }else{
+
+          //in the case someone logs in mid way through, don't replace their work. 
+          if(this.tree.nodes.length > 0) return;
          
 
           const db = fbref(getDatabase());
@@ -412,11 +415,7 @@ export class MixerComponent implements OnInit {
                   fbget(child(db, `users/${this.auth.uid}/ada`)).then((snapshot) => {
                     if (snapshot.exists()) {
                       this.fs.loader.ada("recovered draft", snapshot.val()).then(lr => {
-
-                        console.log(lr);
                         this.loadNewFile(lr);
-
-
                       });
                     }
                   }).catch((error) => {

--- a/src/app/mixer/mixer.component.ts
+++ b/src/app/mixer/mixer.component.ts
@@ -20,6 +20,8 @@ import { SystemsService } from '../core/provider/systems.service';
 import { HttpClient } from '@angular/common/http';
 import { InitModal } from '../core/modal/init/init.modal';
 import { MatDialog } from '@angular/material/dialog';
+import { AuthService } from '../core/provider/auth.service';
+import {getDatabase, ref as fbref, get as fbget, child} from '@angular/fire/database'
 
 
 //disables some angular checking mechanisms
@@ -70,6 +72,7 @@ export class MixerComponent implements OnInit {
    * dialog - Anglar Material dialog module. Used to control the popup modals.
    */
   constructor(public dm: DesignmodesService, 
+    private auth: AuthService,
     private ms: MaterialsService,
     private sys: SystemsService,
     private ps: PatternService, 
@@ -388,14 +391,71 @@ export class MixerComponent implements OnInit {
 
   ngAfterViewInit() {
 
-    const dialogRef = this.dialog.open(InitModal, {
-      data: {source: 'mixer'}
-    });
 
-    dialogRef.afterClosed().subscribe(loadResponse => {
-      if(loadResponse !== undefined) this.loadNewFile(loadResponse);
+      this.auth.user.subscribe(user => {
 
-   });
+        if(user === null){
+          const dialogRef = this.dialog.open(InitModal, {
+            data: {source: 'mixer'}
+          });
+
+          dialogRef.afterClosed().subscribe(loadResponse => {
+            if(loadResponse !== undefined) this.loadNewFile(loadResponse);
+      
+         });
+        }else{
+         
+
+          const db = fbref(getDatabase());
+
+
+                  fbget(child(db, `users/${this.auth.uid}/ada`)).then((snapshot) => {
+                    if (snapshot.exists()) {
+                      this.fs.loader.ada("recovered draft", snapshot.val()).then(lr => {
+
+                        console.log(lr);
+                        this.loadNewFile(lr);
+
+
+                      });
+                    }
+                  }).catch((error) => {
+                    console.error(error);
+                  });
+
+        }
+      });
+  
+    console.log(this.auth, this.auth.isLoggedIn);
+
+
+
+
+
+
+  }
+
+
+  loadSavedFile(){
+  //   this.auth.user.subscribe(user => {
+  //       if(user !== null){
+
+  //         const db = fbref(getDatabase());
+
+
+  //         fbget(child(db, `users/${this.auth.uid}/ada`)).then((snapshot) => {
+  //           if (snapshot.exists()) {
+  //             this.fls.loader.ada("recovered draft", snapshot.val()).then(lr => {
+  //               this.dialogRef.close(lr)
+  //             });
+  //           }
+  //         }).catch((error) => {
+  //           console.error(error);
+  //         });
+    
+  //     }
+    
+  // });
 
   }
 

--- a/src/app/mixer/palette/operation/operation.component.html
+++ b/src/app/mixer/palette/operation/operation.component.html
@@ -80,8 +80,10 @@ cdkDrag
 
         <div class="param-name">{{param.name}}</div>
 
-
-        <div *ngIf="param.max > 1" class="param-slider">
+        <ng-container  *ngIf="param.type == 'number'">
+        <div class="param-slider">
+         
+         
             <mat-slider 
             thumbLabel
             tickInterval="1"
@@ -96,7 +98,7 @@ cdkDrag
         </div>
 
 
-         <div *ngIf="param.max > 1" class='param-label'>
+         <div class='param-label'>
             <input 
             [formControl]="op_inputs[i]"
             [matTooltip]=param.dx
@@ -110,16 +112,38 @@ cdkDrag
           >
   
         </div>
+      </ng-container>
 
-        <div *ngIf="param.max === 1" class="param-checkbox">
-            <mat-checkbox 
-            [formControl]="op_inputs[i]"
-            [matTooltip]=param.dx
-            value="op_inputs[i].value"
-            (change)= "onCheckboxParamChange(i, op_inputs[i].value)">
-        </mat-checkbox>
-        </div>
+      <ng-container  *ngIf="param.type == 'boolean'">
 
+            <div class="param-checkbox">
+                <mat-checkbox 
+                [formControl]="op_inputs[i]"
+                [matTooltip]=param.dx
+                value="op_inputs[i].value"
+                (change)= "onCheckboxParamChange(i, op_inputs[i].value)">
+                </mat-checkbox>
+            </div>
+        </ng-container>
+
+        <ng-container  *ngIf="param.type == 'string'">
+           
+    
+             <div class='param-label'>
+                <input 
+                [formControl]="op_inputs[i]"
+                [matTooltip]=param.dx
+                type = "text"
+                [name]=param.name
+                [min]=param.min
+                [max]=param.max
+                step = 1
+                value = op_inputs[i].value
+                (change)= "onParamChange(i, op_inputs[i].value)"
+              >
+      
+            </div>
+          </ng-container>
     </div>
     </ng-container>
     </div>

--- a/src/app/mixer/palette/subdraft/subdraft.component.html
+++ b/src/app/mixer/palette/subdraft/subdraft.component.html
@@ -102,12 +102,14 @@
 			
 					
 				<div class='dims_and_name'>
-					<div><input matInput [(ngModel)]="tree.getDraft(id).ud_name" [placeholder]="tree.getDraft(id).gen_name"  (focusout)="nameFocusOut($event)"> </div>
+					<div><input matInput [(ngModel)]="tree.getDraft(id).ud_name" 
+						[placeholder]="tree.getDraft(id).gen_name"  
+						(focusout)="nameFocusOut($event)">
+					 </div>
 					<div class="dims">{{tree.getDraft(id).warps}} x {{tree.getDraft(id).wefts}} </div>
 					<div *ngIf="gl.type === 'frame' && (gl.min_frames < tree.getLoom(id).num_frames || gl.min_treadles < tree.getLoom(id).num_treadles) "class="frame">
 						<span class="error">
 							<i matTooltip="This draft requires more than the {{gl.min_frames}} frames or {{gl.min_treadles}} treadles than you have specified for your loom" class="fas fa-exclamation-circle"></i> 
-						
 							{{tree.getLoom(id).num_frames}} frames,  {{tree.getLoom(id).num_treadles}} treadles</span></div>
 					
 					

--- a/src/app/mixer/palette/subdraft/subdraft.component.ts
+++ b/src/app/mixer/palette/subdraft/subdraft.component.ts
@@ -174,6 +174,7 @@ export class SubdraftComponent implements OnInit {
     this.canvas = <HTMLCanvasElement> document.getElementById(this.id.toString());
     this.cx = this.canvas.getContext("2d");
     this.drawDraft(this.draft); //force call here because it likely didn't render previously. 
+
     this.rescale();
     this.updateViewport(this.bounds);
 

--- a/src/app/mixer/provider/operation.service.ts
+++ b/src/app/mixer/provider/operation.service.ts
@@ -680,12 +680,12 @@ export class OperationService {
         value: 0,
         dx: "the amount to offset the added inputs from the left"
         },
-        {name: 'top offset',
+        {name: 'offset from bottom',
         type: 'number',
         min: 0,
         max: 10000,
         value: 0,
-        dx: "the amount to offset the overlaying inputs from the top"
+        dx: "the amount to offset the overlaying inputs from the bottom"
         }
       ],
       max_inputs: 2,
@@ -764,12 +764,12 @@ export class OperationService {
         value: 0,
         dx: "the amount to offset the added inputs from the left"
         },
-        {name: 'top offset',
+        {name: 'bottom offset',
         type: 'number',
         min: 0,
         max: 10000,
         value: 0,
-        dx: "the amount to offset the overlaying inputs from the top"
+        dx: "the amount to offset the overlaying inputs from the bottom"
         }
       ],
       max_inputs: 2,
@@ -829,12 +829,12 @@ export class OperationService {
         value: 0,
         dx: "the amount to offset the added inputs from the left"
         },
-        {name: 'top offset',
+        {name: 'bottom offset',
         type: 'number',
         min: 0,
         max: 10000,
         value: 0,
-        dx: "the amount to offset the overlaying inputs from the top"
+        dx: "the amount to offset the overlaying inputs from the bottom"
         }
       ],
       max_inputs: 2,
@@ -893,12 +893,12 @@ export class OperationService {
         value: 0,
         dx: "the amount to offset the added inputs from the left"
         },
-        {name: 'top offset',
+        {name: 'bottom offset',
         type: 'number',
         min: 0,
         max: 10000,
         value: 0,
-        dx: "the amount to offset the overlaying inputs from the top"
+        dx: "the amount to offset the overlaying inputs from the bottom"
         }
       ],
       max_inputs: 2,
@@ -957,12 +957,12 @@ export class OperationService {
         value: 0,
         dx: "the amount to offset the added inputs from the left"
         },
-        {name: 'top offset',
+        {name: 'bottom offset',
         type: 'number',
         min: 0,
         max: 10000,
         value: 0,
-        dx: "the amount to offset the overlaying inputs from the top"
+        dx: "the amount to offset the overlaying inputs from the bottom"
         }
       ],
       max_inputs: 2,
@@ -1280,12 +1280,12 @@ export class OperationService {
       displayname: 'margin',
       dx: 'adds padding of unset cells to the top, right, bottom, left of the block',
       params: [
-        {name: 'top',
+        {name: 'bottom',
         min: 1,
         max: 10000,
         value: 1,
         type: 'number',
-        dx: 'number of pics of padding to add to the top'
+        dx: 'number of pics of padding to add to the bottom'
         },
         {name: 'right',
         min: 1,
@@ -1294,12 +1294,12 @@ export class OperationService {
         type: 'number',
         dx: 'number of pics of padding to add to the right'
         },
-        {name: 'bottom',
+        {name: 'top',
         min: 1,
         max: 10000,
         value: 1,
         type: 'number',
-        dx: 'number of pics of padding to add to the bottom'
+        dx: 'number of pics of padding to add to the top'
         },
         {name: 'left',
         min: 1,
@@ -1355,12 +1355,12 @@ export class OperationService {
         value: 0,
         dx: 'number of pics from the left to start the cut'
         },
-        {name: 'top',
+        {name: 'bottom',
         type: 'number',
         min: 0,
         max: 10000,
         value: 0,
-        dx: 'number of pics from the top to start the cut'
+        dx: 'number of pics from the bottom to start the cut'
         },
         {name: 'width',
         type: 'number',

--- a/src/app/mixer/provider/operation.service.ts
+++ b/src/app/mixer/provider/operation.service.ts
@@ -33,6 +33,7 @@ export interface ParentOperation {
 
 export interface Operation {
     name: string,
+    displayname: string,
     dx: string,
     max_inputs: number,
     params: Array<OperationParams>,
@@ -72,6 +73,7 @@ export class OperationService {
 
     const rect: Operation = {
       name: 'rectangle',
+      displayname: 'rectangle',
       dx: "generates a rectangle of the user specified side, if given an input, fills the rectangle with the input",
       params: [
         {name: 'width',
@@ -113,6 +115,7 @@ export class OperationService {
 
     const clear: Operation = {
       name: 'clear',
+      displayname: 'clear',
       dx: "this sets all heddles to lifted, allowing it to be masked by any pattern",
       params: [],
       max_inputs: 1,
@@ -132,6 +135,7 @@ export class OperationService {
 
     const set: Operation = {
       name: 'set unset',
+      displayname: 'set unset heddle to',
       dx: "this sets all unset heddles in this draft to the specified value",
       params: [ 
         {name: 'up/down',
@@ -168,7 +172,8 @@ export class OperationService {
 
     const unset: Operation = {
       name: 'set down to unset',
-      dx: "this sets all down heddles in this draft to unset",
+      displayname: 'set heddles of type to unset',
+      dx: "this sets all  heddles of a particular type in this draft to unset",
       params: [
         {name: 'up/down',
         type: 'boolean',
@@ -202,6 +207,7 @@ export class OperationService {
 
     const apply_mats: Operation = {
       name: 'apply materials',
+      displayname: 'apply materials',      
       dx: "applies the materials from the second draft onto the first draft. If they are uneven sizes, it will repeat the materials as a pattern",
       params: [],
       max_inputs: 2,
@@ -224,6 +230,7 @@ export class OperationService {
 
     const rotate: Operation = {
       name: 'rotate',
+      displayname: 'rotate',      
       dx: "this turns the draft by 90 degrees but leaves materials in same place",
       params: [],
       max_inputs: 1,
@@ -253,6 +260,7 @@ export class OperationService {
 
     const interlace:Operation = {
       name: 'interlace',
+      displayname: 'interlace',  
       dx: 'interlace the input drafts together in alternating lines',
       params: [],
       max_inputs: 100,
@@ -298,6 +306,7 @@ export class OperationService {
 
     const splicein:Operation = {
       name: 'splice in wefts',
+      displayname: 'splice in wefts',  
       dx: 'splices the second draft into the first every nth row',
       params: [  
         {name: 'distance',
@@ -366,6 +375,7 @@ export class OperationService {
 
     const assignwefts:Operation = {
       name: 'assign weft systems',
+      displayname: 'assign weft systems',  
       dx: 'splits each pic of the draft apart, allowing it to repeat at a specified interval and shift within that interval. Currently this will overwrite any system information that has been defined upstream',
       params: [  
         {name: 'total',
@@ -437,6 +447,7 @@ export class OperationService {
 
     const assignwarps:Operation = {
       name: 'assign warp systems',
+      displayname: 'assign warp systems',  
       dx: 'splits each warp of the draft apart, allowing it to repeat at a specified interval and shift within that interval. An additional button is used to specify if these systems correspond to layers, and fills in draft accordingly',
       params: [  
         {name: 'total',
@@ -536,6 +547,7 @@ export class OperationService {
 
     const vertcut:Operation = {
       name: 'vertical cut',
+      displayname: 'vertical cut',  
       dx: 'make a vertical of this structure across two systems, representing the left and right side of an opening in the warp',
       params: [  
         {name: 'systems',
@@ -596,6 +608,7 @@ export class OperationService {
 
     const selvedge: Operation = {
       name: 'selvedge',
+      displayname: 'selvedge',  
       dx: 'adds a selvedge of a user defined with both sides of the input draft. User can specify the number of row repeats in the selvedge',
       params: [
         {name: 'width',
@@ -657,6 +670,7 @@ export class OperationService {
 
     const overlay: Operation = {
       name: 'overlay, (a,b) => (a OR b)',
+      displayname: 'overlay, (a,b) => (a OR b)',  
       dx: 'keeps any region that is marked as black/true in either draft',
       params: [
         {name: 'left offset',
@@ -740,6 +754,7 @@ export class OperationService {
 
     const atop: Operation = {
       name: 'set atop, (a, b) => a',
+      displayname: 'set atop, (a, b) => a',  
       dx: 'sets cells of a on top of b, no matter the value of b',
       params: [
         {name: 'left offset',
@@ -804,6 +819,7 @@ export class OperationService {
 
     const knockout: Operation = {
       name: 'knockout, (a, b) => (a XOR b)',
+      displayname: 'knockout, (a, b) => (a XOR b)',  
       dx: 'Flips the value of overlapping cells of the same value, effectively knocking out the image of the second draft upon the first',
       params: [
         {name: 'left offset',
@@ -867,6 +883,7 @@ export class OperationService {
 
     const mask: Operation = {
       name: 'mask, (a,b) => (a AND b)',
+      displayname: 'mask, (a,b) => (a AND b)',
       dx: 'only shows areas of the first draft in regions where the second draft has black/true cells',
       params: [
         {name: 'left offset',
@@ -930,6 +947,7 @@ export class OperationService {
 
     const erase: Operation = {
       name: 'erase,  (a,b) => (NOT a OR b)',
+      displayname: 'erase,  (a,b) => (NOT a OR b)',
       dx: 'Flips the value of overlapping cells of the same value, effectively knocking out the image of the second draft upon the first',
       params: [
         {name: 'left offset',
@@ -994,6 +1012,7 @@ export class OperationService {
 
     const fill: Operation = {
       name: 'fill',
+      displayname: 'fill',
       dx: 'fills black cells of the first input with the pattern specified by the second input, white cells with third input',
       params: [],
       max_inputs: 3,
@@ -1054,6 +1073,7 @@ export class OperationService {
 
     const tabby: Operation = {
       name: 'tabby',
+      displayname: 'tabby',
       dx: 'also known as plain weave generates or fills input a draft with tabby structure or derivitae',
       params: [
         {name: 'repeats',
@@ -1105,6 +1125,7 @@ export class OperationService {
 
     const basket: Operation = {
       name: 'basket',
+      displayname: 'basket',
       dx: 'generates a basket structure defined by the inputs',
       params: [
         {name: 'unders',
@@ -1164,6 +1185,7 @@ export class OperationService {
 
     const stretch: Operation = {
       name: 'stretch',
+      displayname: 'stretch',
       dx: 'repeats each warp and/or weft by the inputs',
       params: [
         {name: 'warp repeats',
@@ -1211,6 +1233,7 @@ export class OperationService {
 
     const resize: Operation = {
       name: 'resize',
+      displayname: 'resize',
       dx: 'stretches or squishes the draft to fit the boundary',
       params: [
         {name: 'warps',
@@ -1254,6 +1277,7 @@ export class OperationService {
 
     const margin: Operation = {
       name: 'margin',
+      displayname: 'margin',
       dx: 'adds padding of unset cells to the top, right, bottom, left of the block',
       params: [
         {name: 'top',
@@ -1321,6 +1345,7 @@ export class OperationService {
 
     const crop: Operation = {
       name: 'crop',
+      displayname: 'crop',
       dx: 'crops to a region of the input draft. The crop size and placement is given by the parameters',
       params: [
         {name: 'left',
@@ -1439,6 +1464,7 @@ export class OperationService {
     
     const rib: Operation = {
       name: 'rib',
+      displayname: 'rib',
       dx: 'generates a rib/cord/half-basket structure defined by the inputs',
       params: [
         {name: 'unders',
@@ -1505,6 +1531,7 @@ export class OperationService {
 
     const twill: Operation = {
       name: 'twill',
+      displayname: 'twill',
       dx: 'generates or fills with a twill structure described by the inputs',
       params: [
         {name: 'unders',
@@ -1573,6 +1600,7 @@ export class OperationService {
 
     const satin: Operation = {
       name: 'satin',
+      displayname: 'satin',
       dx: 'generates or fills with a satin structure described by the inputs',
       params: [
         {name: 'repeat',
@@ -1625,6 +1653,7 @@ export class OperationService {
 
     const random: Operation = {
       name: 'random',
+      displayname: 'random',
       dx: 'generates a random draft with width, height, and percetage of weft unders defined by inputs',
       params: [
         {name: 'width',
@@ -1681,6 +1710,7 @@ export class OperationService {
 
     const invert: Operation = {
       name: 'invert',
+      displayname: 'invert',
       dx: 'generates an output that is the inverse or backside of the input',
       params: [],
       max_inputs: 1, 
@@ -1698,6 +1728,7 @@ export class OperationService {
 
     const flipx: Operation = {
       name: 'flip horiz',
+      displayname: 'flip horiz',
       dx: 'generates an output that is the left-right mirror of the input',
       params: [],
       max_inputs: 1, 
@@ -1715,6 +1746,7 @@ export class OperationService {
 
     const flipy: Operation = {
       name: 'flip vert',
+      displayname: 'flip vert',
       dx: 'generates an output that is the top-bottom mirror of the input',
       params: [],
       max_inputs: 1, 
@@ -1732,6 +1764,7 @@ export class OperationService {
 
     const shiftx: Operation = {
       name: 'shift left',
+      displayname: 'shift left',
       dx: 'generates an output that is shifted left by the number of warps specified in the inputs',
       params: [
         {name: 'amount',
@@ -1760,6 +1793,7 @@ export class OperationService {
 
     const shifty: Operation = {
       name: 'shift up',
+      displayname: 'shift up',
       dx: 'generates an output that is shifted up by the number of wefts specified in the inputs',
       params: [
         {name: 'amount',
@@ -1788,6 +1822,7 @@ export class OperationService {
 
     const slope: Operation = {
       name: 'slope',
+      displayname: 'slope',
       dx: 'offsets every nth row by the vaule given in col',
       params: [
         {name: 'col shift',
@@ -1834,6 +1869,7 @@ export class OperationService {
 
     const replicate: Operation = {
       name: 'mirror',
+      displayname: 'mirror',
       dx: 'generates an linked copy of the input draft, changes to the input draft will then populate on the replicated draft',
       params: [ {
         name: 'copies',
@@ -1863,6 +1899,7 @@ export class OperationService {
 
     const variants: Operation = {
       name: 'variants',
+      displayname: 'variants',
       dx: 'for any input draft, create the shifted and flipped values as well',
       params: [],
       max_inputs: 1, 
@@ -1892,6 +1929,7 @@ export class OperationService {
 
     const bindweftfloats: Operation = {
       name: 'bind weft floats',
+      displayname: 'bind weft floats',
       dx: 'adds interlacements to weft floats over the user specified length',
       params: [
         {name: 'length',
@@ -1934,6 +1972,7 @@ export class OperationService {
 
     const bindwarpfloats: Operation = {
       name: 'bind warp floats',
+      displayname: 'bind warp floats',
       dx: 'adds interlacements to warp floats over the user specified length',
       params: [
         {name: 'length',
@@ -1977,6 +2016,7 @@ export class OperationService {
 
     const layer: Operation = {
       name: 'layer',
+      displayname: 'layer',
       dx: 'creates a draft in which each input is assigned to a layer in a multilayered structure, assigns 1 to top layer and so on',
       params: [],
       max_inputs: 100, 
@@ -2025,6 +2065,7 @@ export class OperationService {
 
     const tile: Operation = {
       name: 'tile',
+      displayname: 'tile',
       dx: 'repeats this block along the warp and weft',
       params: [
         {name: 'warp-repeats',
@@ -2063,6 +2104,7 @@ export class OperationService {
 
     const erase_blank: Operation = {
       name: 'erase blank rows',
+      displayname: 'erase blank rows',
       dx: 'erases any rows that are entirely unset',
       params: [],
       max_inputs: 100, 
@@ -2096,6 +2138,7 @@ export class OperationService {
 
     const jointop: Operation = {
       name: 'join top',
+      displayname: 'join top',
       dx: 'attaches inputs toether into one draft in a column orientation',
       params: [],
       max_inputs: 100, 
@@ -2146,6 +2189,7 @@ export class OperationService {
 
     const joinleft: Operation = {
       name: 'join left',
+      displayname: 'join left',
       dx: 'joins drafts together from left to right',
       params: [],
       max_inputs: 100, 
@@ -2185,18 +2229,14 @@ export class OperationService {
             });
         }
       
-        console.log("joining left, col system map")
-
         d.colSystemMapping = inputs.reduce((acc, draft) => {
           return acc.concat(draft.colSystemMapping);
         }, []);
-        console.log("joining left, col shuttle map")
 
         d.colShuttleMapping = inputs.reduce((acc, draft) => {
           return acc.concat(draft.colShuttleMapping);
         }, []);
              
-        console.log("transfer systems")
 
         this.transferSystemsAndShuttles(d, inputs, input_params, 'joinleft');
         d.gen_name = this.formatName(inputs, "left");
@@ -2209,6 +2249,7 @@ export class OperationService {
 
     const germanify: Operation = {
       name: 'gemanify',
+      displayname: 'gemanify',
       dx: 'uses ML to edit the input based on patterns in a german drafts weave set',
       params: [
         {name: 'output selection',
@@ -2252,6 +2293,7 @@ export class OperationService {
       }  
       const crackleify: Operation = {
         name: 'crackle-ify',
+        displayname: 'crackle-ify',
         dx: 'uses ML to edit the input based on patterns in a german drafts weave set',
         params: [
           {name: 'output selection',
@@ -2296,6 +2338,7 @@ export class OperationService {
         
         const makeloom: Operation = {
           name: 'floor loom',
+          displayname: 'floor loom',
           dx: 'uses the input draft as drawdown and generates a threading, tieup and treadling pattern',
           params: [
 
@@ -2341,6 +2384,7 @@ export class OperationService {
           
           const drawdown: Operation = {
             name: 'drawdown',
+            displayname: 'drawdown',
             dx: 'create a drawdown from the input drafts (order 1. threading, 2. tieup, 3.treadling)',
             params: [
   
@@ -2380,7 +2424,7 @@ export class OperationService {
     
 
 
-    //**push operatiinos to the array here */
+    //**push operations that you want the UI to show as options here */
     this.ops.push(rect);
     this.ops.push(twill);
     this.ops.push(satin);
@@ -2430,7 +2474,6 @@ export class OperationService {
 
 
     //** Give it a classification here */
-
     this.classification.push(
       {category: 'structure',
       dx: "0-1 inputs, 1 output, algorithmically generates weave structures based on parameters",

--- a/src/app/mixer/provider/operation.service.ts
+++ b/src/app/mixer/provider/operation.service.ts
@@ -98,17 +98,13 @@ export class OperationService {
         
         if(inputs.length == 0){
           d.fill([[new Cell(false)]], 'clear');
-          d.gen_name = "rect"
         }else{
           d.fill(inputs[0].pattern, 'original');
           this.transferSystemsAndShuttles(d, inputs, input_params, 'first');
-          d.gen_name = this.formatName(inputs, "rect");
         }
-
-
-
+        d.gen_name = this.formatName(inputs, "rect");
         outputs.push(d);
-        
+
         return Promise.resolve(outputs);
       }        
     }
@@ -560,7 +556,6 @@ export class OperationService {
       max_inputs: 1,
       perform: (inputs: Array<Draft>, input_params: Array<number>) => {
         
-        console.log("inputs", inputs)
 
         if(inputs.length === 0) return Promise.resolve([]);
 
@@ -600,7 +595,6 @@ export class OperationService {
 
           d.gen_name = this.formatName(inputs, "cut+"+i)
           outputs.push(d);
-          console.log("created d", d);
         }
         return Promise.resolve(outputs);
       }     
@@ -1554,7 +1548,7 @@ export class OperationService {
         min: 0,
         max: 1,
         value: 0,
-        dx: 'unchecked for S twist, checked for Z twist'
+        dx: 'unchecked for Z twist, checked for S twist'
         }
       ],
       max_inputs: 1,
@@ -1577,7 +1571,9 @@ export class OperationService {
         let outputs: Array<Draft> = [];
         if(inputs.length == 0){
           const d: Draft = new Draft({warps: sum, wefts: sum, pattern: pattern});
+          d.gen_name = this.formatName(inputs, "twill");
           outputs.push(d);
+
         }else{
            outputs = inputs.map(input => {
             const d: Draft = new Draft({warps: input.warps, wefts: input.wefts, pattern: input.pattern});
@@ -2054,7 +2050,6 @@ export class OperationService {
                 });
               });
 
-              console.log("returning ", d)
               this.transferSystemsAndShuttles(d, inputs, input_params, 'layer');
               d.gen_name = this.formatName(inputs, "layer");
               return [d];
@@ -2195,7 +2190,6 @@ export class OperationService {
       max_inputs: 100, 
       perform: (inputs: Array<Draft>, input_params: Array<number>) => {
         
-        console.log("joining left")
 
         const outputs: Array<Draft> = [];
         const total:number = inputs.reduce((acc, draft)=>{
@@ -2358,7 +2352,6 @@ export class OperationService {
             });
 
             const treadling: Draft = new Draft({warps:l.num_treadles, wefts: inputs[0].wefts});
-            console.log(treadling);
             l.treadling.forEach((treadle_num, i) =>{
               if(treadle_num !== -1) treadling.pattern[i][treadle_num].setHeddle(true);
             });
@@ -2568,7 +2561,6 @@ export class OperationService {
           break;
 
           case 'joinleft':
-          console.log("join left");
             //if there are multiple inputs, 
             d.updateWeftShuttlesFromPattern(inputs[0].rowShuttleMapping);
             d.updateWeftSystemsFromPattern(inputs[0].rowSystemMapping);
@@ -2652,7 +2644,6 @@ export class OperationService {
                 
     }
 
-    console.log("transfered");
 
 
 
@@ -2660,12 +2651,19 @@ export class OperationService {
 
   formatName(inputs: Array<Draft>, op_name: string) : string{
 
-    const combined = inputs.reduce((acc, el) => {
-      return acc+"+"+el.getName()
-    }, "");
+    let combined: string = "";
 
-    //return op_name+"("+combined.substr(1)+")";
-    return combined.substr(1);
+    if(inputs.length == 0){
+      combined = op_name;
+    }else{
+
+      combined = inputs.reduce((acc, el) => {
+        return acc+"+"+el.getName();
+      }, "");
+      combined = op_name+"("+combined.substring(1)+")";
+    }
+
+    return combined;
   }
 
 

--- a/src/app/mixer/provider/tree.service.ts
+++ b/src/app/mixer/provider/tree.service.ts
@@ -1079,26 +1079,30 @@ removeOperationNode(id:number) : Array<Node>{
 
 
  /**
-  * takes a draft as input, and flips the orientation of the cells 
+  * takes a draft as input, and flips the order of the rows, used 
   * @param draft 
   */ 
 flipDraft(draft: Draft) : Draft{
 
-  console.log("draft in", draft)  
-  const reversed:Array<Array<Cell>> = [];
+  const nd: Draft = new Draft({warps: draft.warps, wefts:draft.wefts});
+  const reversed_pattern:Array<Array<Cell>> = [];
+  const reversed_row_shut:Array<number> = [];
+  const reversed_row_sys:Array<number> = [];
   for(let i = draft.pattern.length -1; i >= 0; i--){
-    reversed.push(draft.pattern[i]);
+    reversed_pattern.push(draft.pattern[i]);
+    reversed_row_shut.push(draft.rowShuttleMapping[i]);
+    reversed_row_sys.push(draft.rowSystemMapping[i]);
   }
-  draft.pattern = reversed;
-  console.log("draft out", draft);
-  return draft;
+  nd.pattern = reversed_pattern;
+  nd.rowShuttleMapping = reversed_row_shut;
+  nd.rowSystemMapping = reversed_row_sys;
+  return nd;
 }
 
 
 
 /**
  * performs the given operation
- * inverts the draft first, so drafts build from bottom up
  * returns the list of draft ids affected by this calculation
  * @param op_id the operation triggering this series of update
  */
@@ -1120,13 +1124,13 @@ flipDraft(draft: Draft) : Draft{
     .filter(el => el !== null && el !== undefined)
     .map(el => this.flipDraft(el));
   
+    console.log("input drafts", input_drafts.map(el => el.pattern));
   return op.perform(input_drafts, node.params)
     .then(res => {
       const flipped: Array<Draft> = res.map(el => this.flipDraft(el));
-      console.log("finished performing op", id, res, flipped);
       node.dirty = false;
       return this.updateDraftsFromResults(id, flipped)
-    })
+    });
   }
 
 

--- a/src/app/mixer/provider/tree.service.ts
+++ b/src/app/mixer/provider/tree.service.ts
@@ -121,7 +121,6 @@ export class TreeService {
 
 
   setOpParams(id: number, params: Array<number>){
-    console.log("id, params", id, params)
     this.getOpNode(id).params = params;
   }
 
@@ -366,7 +365,6 @@ export class TreeService {
    * @returns  true if the id maps to a subdraft
    */
   setOpenConnection(id: number) : boolean {
-    console.log("setting open connection", id, this.getType(id));
     if(this.getType(id) !== 'draft') return false;
     this.open_connection = id; 
     console.log("set open connection", id)
@@ -374,7 +372,6 @@ export class TreeService {
   }
 
   hasOpenConnection():boolean{
-    console.log("has connection", this.open_connection)
     return this.open_connection !== -1;
   }
 
@@ -719,7 +716,6 @@ export class TreeService {
    * @returns an array of operation ids for nodes that need recalculating
    */
   getDownstreamOperations(id: number):Array<number>{
-    console.log("getting downsteam");
 
     let ops: Array<number> = [];
     const tn: TreeNode = this.getTreeNode(id);
@@ -823,11 +819,11 @@ export class TreeService {
     return acc.concat(this.getInputs(el))
   }, []);
 
-  console.log("Ops in", ops_in);
-  console.log("CXNs in", cxns_in);
-  console.log("CXNs out", cxns_out);
-  console.log("OPSs out", ops_out);
-  console.log("op connections in", op_in_cxns);
+  // console.log("Ops in", ops_in);
+  // console.log("CXNs in", cxns_in);
+  // console.log("CXNs out", cxns_out);
+  // console.log("OPSs out", ops_out);
+  // console.log("op connections in", op_in_cxns);
 
   deleted.push(this.removeNode(id));
 
@@ -1056,7 +1052,6 @@ removeOperationNode(id:number) : Array<Node>{
    * @returns //need a way to get this to return any drafts that it touched along the way
    */
   performGenerationOps(op_node_list: Array<number>) : Promise<any> {
-    console.log("performing generation");
 
     const op_fn_list = op_node_list.map(el => this.performOp(el));
    
@@ -1084,7 +1079,7 @@ removeOperationNode(id:number) : Array<Node>{
   */ 
 flipDraft(draft: Draft) : Draft{
 
-  const nd: Draft = new Draft({warps: draft.warps, wefts:draft.wefts});
+  const nd: Draft = new Draft(draft);
   const reversed_pattern:Array<Array<Cell>> = [];
   const reversed_row_shut:Array<number> = [];
   const reversed_row_sys:Array<number> = [];
@@ -1107,7 +1102,6 @@ flipDraft(draft: Draft) : Draft{
  * @param op_id the operation triggering this series of update
  */
  async performOp(id:number) : Promise<Array<number>> {
-  console.log("performing op", id);
 
   //mark all downsteam nodes as dirty; 
   const ds = this.getDownstreamOperations(id);
@@ -1124,7 +1118,6 @@ flipDraft(draft: Draft) : Draft{
     .filter(el => el !== null && el !== undefined)
     .map(el => this.flipDraft(el));
   
-    console.log("input drafts", input_drafts.map(el => el.pattern));
   return op.perform(input_drafts, node.params)
     .then(res => {
       const flipped: Array<Draft> = res.map(el => this.flipDraft(el));
@@ -1561,7 +1554,7 @@ flipDraft(draft: Draft) : Draft{
   setDraft(id: number, temp: Draft, loom: Loom) {
 
     const dn = <DraftNode> this.getNode(id);
-    let ud_name = temp.ud_name;
+    let ud_name = temp.getName();
 
     if(dn.draft === null){
       dn.draft = temp;


### PR DESCRIPTION
Minor Updates and Indexes: 
-- Changed origin for drafts to be bottom left instead of top left. I did this by flipping drafts before and after ops are combined. This causes a twill to build from bottom left up instead of top right down. Additionally, changed naming of "top" offsets to bottom offsets.

-- Allowed naming support on zero input drafts

-- Added autoload for logged in users. 

-- deleted old print statements from tree. 