### PR TITLE
Improvements to Zoom and Drag

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -245,7 +245,7 @@
         
             <button  mat-icon-button (click)="zoomIn()"><i class="fas fa-search-plus"></i></button>
             
-            <button mat-flat-button (click)="zoomToFit()">Fit</button>
+            <button mat-icon-button (click)="zoomToFit()"><i class="fa-solid fa-arrows-to-eye"></i></button>
             
             
             <button  

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -244,6 +244,10 @@
            
         
             <button  mat-icon-button (click)="zoomIn()"><i class="fas fa-search-plus"></i></button>
+            
+            <button mat-flat-button (click)="zoomToFit()">Fit</button>
+            
+            
             <button  
             mat-icon-button 
             [disabled]="ss.undo_disabled"
@@ -251,6 +255,10 @@
             (click)="undo()" >
             <i class="fa-solid fa-rotate-left"></i>
             </button>
+
+
+
+
       
             <button  
             mat-icon-button 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1461,11 +1461,6 @@ redo() {
       let comp= this.tree.getComponent(id);
       (<SubdraftComponent> comp).draftcontainer.updateName();
     }
-    
-   
-
-
-
   }
 
   renameWorkspace(name: string){
@@ -1505,27 +1500,24 @@ redo() {
   zoomToFit(){
 
     const view_window:HTMLElement = document.getElementById('scrollable-container');
-    const child:HTMLElement = document.getElementById('palette-scale-container');
     if(view_window === null || view_window === undefined) return;
 
-    console.log("DIV window", view_window.scrollLeft)
-    console.log("DIV palette scale", child, child.getBoundingClientRect())
-   
 
     if(this.viewer.view_expanded){
       this.viewer.renderChange();
     }else if(this.selected_editor_mode == 'mixer'){
 
      
-      const b_nodes = this.tree.getNodeBoundingBox(this.zs.getMixerZoom());
-      const n_nodes = this.notes.getNoteBoundingBox(this.zs.getMixerZoom());
-
-
+      const b_nodes = this.tree.getNodeBoundingBox();
+      const n_nodes = this.notes.getNoteBoundingBox();
       const bounds = utilInstance.mergeBounds([b_nodes, n_nodes]);
       
       if(bounds == null) return;
 
+      console.log("ZOOM TO FIT ", bounds, view_window.getBoundingClientRect());
+      let prior = this.zs.getMixerZoom();
       this.zs.zoomToFitMixer(bounds, view_window.getBoundingClientRect());
+      this.mixer.renderChange(prior);
 
       //since bounds is in absolute terms (relative to the child div, we need to convert the top left into the scaled space)
       view_window.scroll({
@@ -1535,7 +1527,6 @@ redo() {
       })
 
 
-      this.mixer.renderChange();
 
 
 
@@ -1546,12 +1537,18 @@ redo() {
   }
 
   zoomOut(){
+
     if(this.viewer.view_expanded){
       this.zs.zoomOutViewer();
       this.viewer.renderChange();
     }else if(this.selected_editor_mode == 'mixer'){
+      const prior = this.zs.getMixerZoom();
       this.zs.zoomOutMixer();
-      this.mixer.renderChange();
+      this.mixer.renderChange(prior);
+
+
+
+
     } else {
       this.zs.zoomOutEditor()
       this.editor.renderChange();
@@ -1563,8 +1560,9 @@ redo() {
       this.zs.zoomInViewer();
       this.viewer.renderChange();
     }else if(this.selected_editor_mode == 'mixer'){
+      const prior = this.zs.getMixerZoom();
       this.zs.zoomInMixer();
-      this.mixer.renderChange();
+      this.mixer.renderChange(prior);
     } else {
       this.zs.zoomInEditor()
       this.editor.renderChange();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -190,7 +190,6 @@ export class AppComponent implements OnInit{
   }
 
 
-
   clearAll() : void{
 
     this.vs.clearPin();
@@ -1507,12 +1506,14 @@ redo() {
       this.viewer.renderChange();
     }else if(this.selected_editor_mode == 'mixer'){
 
-     
-      const b_nodes = this.tree.getNodeBoundingBox();
-      const n_nodes = this.notes.getNoteBoundingBox();
-      const bounds = utilInstance.mergeBounds([b_nodes, n_nodes]);
-      console.log("MERGED BOUNDS", bounds);
+      let selections = this.multiselect.getSelections();  
 
+      let node_list = (selections.length == 0) ? this.tree.getNodeIdList() : selections;
+      let note_list = (selections.length == 0) ? this.notes.getNoteIdList() : [];
+
+      const b_nodes = this.tree.getNodeBoundingBox(node_list);
+      const n_nodes =  this.notes.getNoteBoundingBox(note_list);
+      const bounds = utilInstance.mergeBounds([b_nodes, n_nodes]);
       
       if(bounds == null) return;
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1511,10 +1511,11 @@ redo() {
       const b_nodes = this.tree.getNodeBoundingBox();
       const n_nodes = this.notes.getNoteBoundingBox();
       const bounds = utilInstance.mergeBounds([b_nodes, n_nodes]);
+      console.log("MERGED BOUNDS", bounds);
+
       
       if(bounds == null) return;
 
-      console.log("ZOOM TO FIT ", bounds, view_window.getBoundingClientRect());
       let prior = this.zs.getMixerZoom();
       this.zs.zoomToFitMixer(bounds, view_window.getBoundingClientRect());
       this.mixer.renderChange(prior);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1274,7 +1274,7 @@ async processFileData(data: FileObj) : Promise<string|void>{
     this.mixer.refreshOperations();
     this.mixer.renderChange();
     this.editor.renderChange();
-  
+
     return Promise.resolve('alldone')
   })
   .catch(e => {

--- a/src/app/core/model/util.ts
+++ b/src/app/core/model/util.ts
@@ -285,7 +285,7 @@ class Util {
     const tlbr = list.reduce((acc, val) => {
 
       if(val.topleft.x < acc.topleft.x) acc.topleft.x = val.topleft.x;
-      if(val.topleft.y < acc.topleft.y) acc.topleft.x = val.topleft.y;
+      if(val.topleft.y < acc.topleft.y) acc.topleft.y = val.topleft.y;
       if(val.topleft.x+val.width > acc.botright.x) acc.botright.x = val.topleft.x + val.width;
       if(val.topleft.y+val.height > acc.botright.y) acc.botright.y = val.topleft.y + val.height;
       return acc;

--- a/src/app/core/model/util.ts
+++ b/src/app/core/model/util.ts
@@ -269,6 +269,38 @@ class Util {
   }
 
 
+
+  /**
+   * given a list of Bounds objects, this function will merge the bounds such that the top left point represents the top-most and left-most of the values and the width and height contain all values
+   * @param list 
+   * @returns 
+   */
+  mergeBounds(list: Array<Bounds>) : Bounds | null {
+
+    list = list.filter(el => el !== null && el !== undefined);
+    if(list.length == 0) return null;
+
+    const first = list.pop();
+
+    const tlbr = list.reduce((acc, val) => {
+
+      if(val.topleft.x < acc.topleft.x) acc.topleft.x = val.topleft.x;
+      if(val.topleft.y < acc.topleft.y) acc.topleft.x = val.topleft.y;
+      if(val.topleft.x+val.width > acc.botright.x) acc.botright.x = val.topleft.x + val.width;
+      if(val.topleft.y+val.height > acc.botright.y) acc.botright.y = val.topleft.y + val.height;
+      return acc;
+    }, {topleft: first.topleft, botright: {x: first.topleft.x + first.width, y: first.topleft.y + first.height}})
+
+
+    return {
+      topleft: {x: tlbr.topleft.x, y: tlbr.topleft.y},
+      width: (tlbr.botright.x - tlbr.topleft.x),
+      height: (tlbr.botright.y - tlbr.topleft.y),
+    }
+
+  }
+
+
   /**
    * finds the right-most component, used to create bounding box 
    * @param main the component we are comparing to

--- a/src/app/core/provider/notes.service.ts
+++ b/src/app/core/provider/notes.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ViewRef } from '@angular/core';
 import { NoteComponent } from '../../mixer/palette/note/note.component';
-import { Interlacement, Note, Point } from '../model/datatypes';
+import { Bounds, Interlacement, Note, Point } from '../model/datatypes';
 import utilInstance from '../model/util';
 
 
@@ -115,6 +115,40 @@ export class NotesService {
       height: note.height
     }
     });
+  }
+
+  /**
+   * returns the minimum bounding box that can contain all the notes values for each note that is currently visible. 
+   * @returns 
+   */
+  getNoteBoundingBox():Bounds{
+    
+    const raw_rects =  this.notes
+    .map(note => document.getElementById('note-'+note.id))
+    .filter(div => div !== null)
+    .map(div => div.getBoundingClientRect());
+
+    const min: Point = raw_rects.reduce((acc, el) => {
+      if(el.x < acc.x) acc.x = el.x;
+      if(el.y < acc.y) acc.y = el.y;
+      return acc;
+    }, {x: 1000000, y:100000});
+
+    const max: Point = raw_rects.reduce((acc, el) => {
+      if(el.right > acc.x) acc.x = el.right;
+      if(el.bottom > acc.y) acc.y = el.bottom;
+      return acc;
+    }, {x: 0, y:0});
+
+
+    let bounds:Bounds = {
+      topleft: {x: min.x, y: min.y},
+      width: max.x - min.x,
+      height: max.y - min.y
+    }
+
+    return bounds;
+
   }
 
   // /** called on load new file as well as undo, redo  */

--- a/src/app/core/provider/notes.service.ts
+++ b/src/app/core/provider/notes.service.ts
@@ -123,6 +123,8 @@ export class NotesService {
    */
   getNoteBoundingBox():Bounds|null{
     
+    if(this.notes.length == 0) return null;
+
     const raw_rects =  this.notes
     .map(note => document.getElementById('note-'+note.id))
     .filter(div => div !== null)

--- a/src/app/core/provider/notes.service.ts
+++ b/src/app/core/provider/notes.service.ts
@@ -121,12 +121,12 @@ export class NotesService {
    * this function returns the smallest bounding box that can contain all of the notes. This function does not consider the scrolling (all measures are relative to the current view window). getClientRect factors in scale, so the x, y and width/height will have the current scaling factored in. To adjust for this, this function needs to take in the current zoom
    * @returns The Bounds or null (if there are no nodes with which to measure)
    */
-  getNoteBoundingBox():Bounds|null{
+  getNoteBoundingBox(id_list: Array<number>):Bounds|null{
     
-    if(this.notes.length == 0) return null;
+    if(this.notes.length == 0 || id_list.length == 0) return null;
 
-    const raw_rects =  this.notes
-    .map(note => document.getElementById('note-'+note.id))
+    const raw_rects =  id_list
+    .map(id => document.getElementById('note-'+id))
     .filter(div => div !== null)
     .map(div => { return {x: div.offsetLeft, y: div.offsetTop, width: div.offsetWidth, height: div.offsetHeight}});
 
@@ -154,7 +154,7 @@ export class NotesService {
       height: max.y - min.y
     }
 
-    console.log('BOUNDS FOR NOTES', min, max, bounds)
+    //console.log('BOUNDS FOR NOTES', min, max, bounds)
     return bounds;
    
 
@@ -204,6 +204,10 @@ export class NotesService {
     let note = this.get(id);
     note.color = color;
   } 
+
+  getNoteIdList(){
+    return this.notes.map(note => note.id);
+  }
 
 
 }

--- a/src/app/core/provider/notes.service.ts
+++ b/src/app/core/provider/notes.service.ts
@@ -118,25 +118,31 @@ export class NotesService {
   }
 
   /**
-   * returns the minimum bounding box that can contain all the notes values for each note that is currently visible. 
-   * @returns 
+   * this function returns the smallest bounding box that can contain all of the notes. This function does not consider the scrolling (all measures are relative to the current view window). getClientRect factors in scale, so the x, y and width/height will have the current scaling factored in. To adjust for this, this function needs to take in the current zoom
+   * @returns The Bounds or null (if there are no nodes with which to measure)
    */
-  getNoteBoundingBox():Bounds{
+  getNoteBoundingBox(current_zoom):Bounds|null{
     
+    if(this.notes.length == 0) return null;
+
     const raw_rects =  this.notes
     .map(note => document.getElementById('note-'+note.id))
     .filter(div => div !== null)
     .map(div => div.getBoundingClientRect());
 
     const min: Point = raw_rects.reduce((acc, el) => {
-      if(el.x < acc.x) acc.x = el.x;
-      if(el.y < acc.y) acc.y = el.y;
+      let adj_x =  el.x * 1/current_zoom;
+      let adj_y =  el.y * 1/current_zoom;
+      if(el.x < acc.x) acc.x = adj_x;
+      if(el.y < acc.y) acc.y = adj_y;
       return acc;
     }, {x: 1000000, y:100000});
 
     const max: Point = raw_rects.reduce((acc, el) => {
-      if(el.right > acc.x) acc.x = el.right;
-      if(el.bottom > acc.y) acc.y = el.bottom;
+      let adj_right = el.right * 1/current_zoom;
+      let adj_bottom = el.bottom * 1/current_zoom;
+      if(adj_right > acc.x) acc.x = adj_right;
+      if(adj_bottom  > acc.y) acc.y = adj_bottom;
       return acc;
     }, {x: 0, y:0});
 
@@ -146,6 +152,7 @@ export class NotesService {
       width: max.x - min.x,
       height: max.y - min.y
     }
+    console.log('BOUNDS FOR Notes', bounds)
 
     return bounds;
 

--- a/src/app/core/provider/notes.service.ts
+++ b/src/app/core/provider/notes.service.ts
@@ -121,26 +121,25 @@ export class NotesService {
    * this function returns the smallest bounding box that can contain all of the notes. This function does not consider the scrolling (all measures are relative to the current view window). getClientRect factors in scale, so the x, y and width/height will have the current scaling factored in. To adjust for this, this function needs to take in the current zoom
    * @returns The Bounds or null (if there are no nodes with which to measure)
    */
-  getNoteBoundingBox(current_zoom):Bounds|null{
+  getNoteBoundingBox():Bounds|null{
     
-    if(this.notes.length == 0) return null;
-
     const raw_rects =  this.notes
     .map(note => document.getElementById('note-'+note.id))
     .filter(div => div !== null)
-    .map(div => div.getBoundingClientRect());
+    .map(div => { return {x: div.offsetLeft, y: div.offsetTop, width: div.offsetWidth, height: div.offsetHeight}});
 
+    
     const min: Point = raw_rects.reduce((acc, el) => {
-      let adj_x =  el.x * 1/current_zoom;
-      let adj_y =  el.y * 1/current_zoom;
-      if(el.x < acc.x) acc.x = adj_x;
-      if(el.y < acc.y) acc.y = adj_y;
+      let adj_x =  el.x;
+      let adj_y =  el.y;
+      if(adj_x < acc.x) acc.x = adj_x;
+      if(adj_y < acc.y) acc.y = adj_y;
       return acc;
     }, {x: 1000000, y:100000});
 
     const max: Point = raw_rects.reduce((acc, el) => {
-      let adj_right = el.right * 1/current_zoom;
-      let adj_bottom = el.bottom * 1/current_zoom;
+      let adj_right = el.x + el.width;
+      let adj_bottom = el.y + el.height;
       if(adj_right > acc.x) acc.x = adj_right;
       if(adj_bottom  > acc.y) acc.y = adj_bottom;
       return acc;
@@ -152,9 +151,10 @@ export class NotesService {
       width: max.x - min.x,
       height: max.y - min.y
     }
-    console.log('BOUNDS FOR Notes', bounds)
 
+    console.log('BOUNDS FOR NOTES', min, max, bounds)
     return bounds;
+   
 
   }
 

--- a/src/app/core/provider/tree.service.ts
+++ b/src/app/core/provider/tree.service.ts
@@ -656,7 +656,7 @@ export class TreeService {
    * this function returns the smallest bounding box that can contain all of the nodes. This function does not consider the scrolling (all measures are relative to the node parent (palette-scale-container). This means that the values will be the same no matter the scroll or the zoom. 
    * @returns The Bounds or null (if there are no nodes with which to measure)
    */
-  getNodeBoundingBox(current_zoom:number):Bounds|null{
+  getNodeBoundingBox():Bounds|null{
 
     if(this.nodes.length == 0) return null;
 
@@ -665,9 +665,6 @@ export class TreeService {
     .map(node => document.getElementById('scale-'+node))
     .filter(div => div != null)
     .map(div => { return {x: div.offsetLeft, y: div.offsetTop, width: div.offsetWidth, height: div.offsetHeight}});
-
-
-    console.log("rect ", raw_rects)
 
     const min: Point = raw_rects.reduce((acc, el) => {
       let adj_x =  el.x;

--- a/src/app/core/provider/tree.service.ts
+++ b/src/app/core/provider/tree.service.ts
@@ -653,15 +653,15 @@ export class TreeService {
 
 
   /**
-   * this function returns the smallest bounding box that can contain all of the nodes. This function does not consider the scrolling (all measures are relative to the node parent (palette-scale-container). This means that the values will be the same no matter the scroll or the zoom. 
+   * this function returns the smallest bounding box that can contain all of the input nodes. This function does not consider the scrolling (all measures are relative to the node parent (palette-scale-container). This means that the values will be the same no matter the scroll or the zoom. 
    * @returns The Bounds or null (if there are no nodes with which to measure)
    */
-  getNodeBoundingBox():Bounds|null{
+  getNodeBoundingBox(node_ids: Array<number>):Bounds|null{
 
     if(this.nodes.length == 0) return null;
 
 
-    const raw_rects=  this.getNodeIdList()
+    const raw_rects= node_ids
     .map(node => document.getElementById('scale-'+node))
     .filter(div => div != null)
     .map(div => { return {x: div.offsetLeft, y: div.offsetTop, width: div.offsetWidth, height: div.offsetHeight}});
@@ -689,7 +689,7 @@ export class TreeService {
       height: max.y - min.y
     }
 
-    console.log('BOUNDS FOR COMPONENTS', min, max, bounds)
+    // console.log('BOUNDS FOR COMPONENTS', min, max, bounds)
     return bounds;
   
   }

--- a/src/app/core/provider/tree.service.ts
+++ b/src/app/core/provider/tree.service.ts
@@ -650,26 +650,38 @@ export class TreeService {
     return this.nodes[ndx]; 
   }
 
-  //this function returns the smallest bounding box that can contain all of the nodes. 
-  //this function does not consider the scrolling (all measures are relative to the current view window. )
-  //getClientRect factors in scale, so the x, y and width/height will have the current scaling factored in. 
-  getNodeBoundingBox():Bounds{
 
-    const raw_rects =  this.getNodeIdList()
+
+  /**
+   * this function returns the smallest bounding box that can contain all of the nodes. This function does not consider the scrolling (all measures are relative to the node parent (palette-scale-container). This means that the values will be the same no matter the scroll or the zoom. 
+   * @returns The Bounds or null (if there are no nodes with which to measure)
+   */
+  getNodeBoundingBox(current_zoom:number):Bounds|null{
+
+    if(this.nodes.length == 0) return null;
+
+
+    const raw_rects=  this.getNodeIdList()
     .map(node => document.getElementById('scale-'+node))
     .filter(div => div != null)
-    .map(div => div.getBoundingClientRect());
+    .map(div => { return {x: div.offsetLeft, y: div.offsetTop, width: div.offsetWidth, height: div.offsetHeight}});
 
+
+    console.log("rect ", raw_rects)
 
     const min: Point = raw_rects.reduce((acc, el) => {
-      if(el.x < acc.x) acc.x = el.x;
-      if(el.y < acc.y) acc.y = el.y;
+      let adj_x =  el.x;
+      let adj_y =  el.y;
+      if(adj_x < acc.x) acc.x = adj_x;
+      if(adj_y < acc.y) acc.y = adj_y;
       return acc;
     }, {x: 1000000, y:100000});
 
     const max: Point = raw_rects.reduce((acc, el) => {
-      if(el.right > acc.x) acc.x = el.right;
-      if(el.bottom > acc.y) acc.y = el.bottom;
+      let adj_right = el.x + el.width;
+      let adj_bottom = el.y + el.height;
+      if(adj_right > acc.x) acc.x = adj_right;
+      if(adj_bottom  > acc.y) acc.y = adj_bottom;
       return acc;
     }, {x: 0, y:0});
 
@@ -680,6 +692,7 @@ export class TreeService {
       height: max.y - min.y
     }
 
+    console.log('BOUNDS FOR COMPONENTS', min, max, bounds)
     return bounds;
   
   }

--- a/src/app/core/provider/tree.service.ts
+++ b/src/app/core/provider/tree.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ViewRef } from '@angular/core';
 import { boolean } from 'mathjs';
-import { BoolParam, Draft, DraftNode, DraftNodeProxy, Drawdown, DynamicOperation, IndexedColorImageInstance, IOTuple, Loom, LoomSettings, Node, NodeComponentProxy, NotationTypeParam, OpComponentProxy, Operation, OpInput, OpNode, OpParamVal, StringParam, TreeNode, TreeNodeProxy } from '../../core/model/datatypes';
+import { BoolParam, Bounds, Draft, DraftNode, DraftNodeProxy, Drawdown, DynamicOperation, IndexedColorImageInstance, IOTuple, Loom, LoomSettings, Node, NodeComponentProxy, NotationTypeParam, OpComponentProxy, Operation, OpInput, OpNode, OpParamVal, Point, StringParam, TreeNode, TreeNodeProxy } from '../../core/model/datatypes';
 import { compressDraft, copyDraft, createDraft, exportDrawdownToArray, getDraftName, initDraft, initDraftWithParams, warps, wefts } from '../../core/model/drafts';
 import { copyLoom, flipLoom, getLoomUtilByType } from '../../core/model/looms';
 import utilInstance from '../../core/model/util';
@@ -649,6 +649,42 @@ export class TreeService {
     if(ndx === -1) return null;
     return this.nodes[ndx]; 
   }
+
+  //this function returns the smallest bounding box that can contain all of the nodes. 
+  //this function does not consider the scrolling (all measures are relative to the current view window. )
+  //getClientRect factors in scale, so the x, y and width/height will have the current scaling factored in. 
+  getNodeBoundingBox():Bounds{
+
+    const raw_rects =  this.getNodeIdList()
+    .map(node => document.getElementById('scale-'+node))
+    .filter(div => div != null)
+    .map(div => div.getBoundingClientRect());
+
+
+    const min: Point = raw_rects.reduce((acc, el) => {
+      if(el.x < acc.x) acc.x = el.x;
+      if(el.y < acc.y) acc.y = el.y;
+      return acc;
+    }, {x: 1000000, y:100000});
+
+    const max: Point = raw_rects.reduce((acc, el) => {
+      if(el.right > acc.x) acc.x = el.right;
+      if(el.bottom > acc.y) acc.y = el.bottom;
+      return acc;
+    }, {x: 0, y:0});
+
+
+    let bounds:Bounds = {
+      topleft: {x: min.x, y: min.y},
+      width: max.x - min.x,
+      height: max.y - min.y
+    }
+
+    return bounds;
+  
+  }
+
+
 
   getNodeIdList() : Array<number> {
     return this.nodes.map(node => node.id);

--- a/src/app/core/provider/version.service.ts
+++ b/src/app/core/provider/version.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 })
 export class VersionService {
 
-  private version: string = '4.2.7'
+  private version: string = '4.2.8'
 
 
   constructor() { 

--- a/src/app/core/provider/zoom.service.ts
+++ b/src/app/core/provider/zoom.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { defaults } from '../model/defaults';
-import { ZoomProxy } from '../model/datatypes';
+import { Bounds, ZoomProxy } from '../model/datatypes';
 
 @Injectable({
   providedIn: 'root'
@@ -9,8 +9,8 @@ export class ZoomService {
   //current zoom scale
   
 
-  num_steps: number = 20;
-  zoom_min: number = .1;
+  num_steps: number = 30;
+  zoom_min: number = .001;
   zoom_step: number = .004;
   zoom_table: Array<number> = [];
 
@@ -55,6 +55,50 @@ export class ZoomService {
   manageZoomRounding(val: number) : number {
     // if(val >= 1) return Math.floor(val);
     return Math.round(val * 1000) / 1000; 
+  }
+
+
+  /**
+   * this function takes a bounding box and view box and updates the zoom such that the bounding box fits within the view box. 
+   * @param objs 
+   * @param viewable (the size of the current view portal) 
+   */
+  zoomToFitMixer(objs: Bounds, viewable: {width: number, height: number}){
+
+    let factor = 1;
+    
+
+    console.log("BOUNDS ", objs, viewable);
+    //get the constraining dimension from the viewable; 
+    if(viewable.width > viewable.height){
+        //constrained by height
+        factor = viewable.height / objs.height;
+        console.log('CONSTRAINED BY HEIGHT', factor)
+
+        // let res_width = objs.width * factor;
+        // if(res_width > viewable.height){
+        //   factor = objs.width/ viewable.width;
+        // }
+
+    }else{
+      factor = objs.width / viewable.width;
+
+      let res_height = objs.height * factor;
+      if(res_height > viewable.height){
+        factor = objs.height/ viewable.height;
+      }
+    }
+    this.setMixerIndexFromZoomValue(factor);
+
+
+  }
+
+  zoomToFitEditor(){
+    
+  }
+
+  zoomToVitViewer(){
+
   }
 
 
@@ -123,6 +167,7 @@ export class ZoomService {
   }
 
   setMixerIndexFromZoomValue(zoom: number){
+    console.log("SETTING TO ", zoom)
     let closest = this.zoom_table.reduce((acc, val, ndx) => {
       let diff = zoom - val;
       if(diff >= 0 && diff < acc.min) return {min: diff, ndx: ndx}
@@ -131,6 +176,7 @@ export class ZoomService {
     }, {min: 1000000, ndx: 0})
 
     this.zoom_table_ndx_mixer=  closest.ndx;
+    console.log("SET TO ", this.zoom_table_ndx_mixer, this.zoom_table[this.zoom_table_ndx_mixer])
 
   }
 

--- a/src/app/core/provider/zoom.service.ts
+++ b/src/app/core/provider/zoom.service.ts
@@ -59,20 +59,20 @@ export class ZoomService {
 
 
   /**
-   * this function takes a bounding box and view box and updates the zoom such that the bounding box fits within the view box. 
+   * this function takes a bounding box and the total size of the palette and updates the zoom such that the bounding box fits within the view box. 
    * @param objs 
    * @param viewable (the size of the current view portal) 
    */
-  zoomToFitMixer(objs: Bounds, viewable: {width: number, height: number}){
+  zoomToFitMixer(bounds: Bounds, viewable: {width: number, height: number}){
 
     let factor = 1;
-    
 
-    console.log("BOUNDS ", objs, viewable);
+    console.log("BOUNDS ", bounds, viewable);
     //get the constraining dimension from the viewable; 
+   
     if(viewable.width > viewable.height){
         //constrained by height
-        factor = viewable.height / objs.height;
+        factor = viewable.height / bounds.height;
         console.log('CONSTRAINED BY HEIGHT', factor)
 
         // let res_width = objs.width * factor;
@@ -81,11 +81,11 @@ export class ZoomService {
         // }
 
     }else{
-      factor = objs.width / viewable.width;
+      factor = bounds.width / viewable.width;
 
-      let res_height = objs.height * factor;
+      let res_height = bounds.height * factor;
       if(res_height > viewable.height){
-        factor = objs.height/ viewable.height;
+        factor = bounds.height/ viewable.height;
       }
     }
     this.setMixerIndexFromZoomValue(factor);

--- a/src/app/core/provider/zoom.service.ts
+++ b/src/app/core/provider/zoom.service.ts
@@ -10,8 +10,8 @@ export class ZoomService {
   
 
   num_steps: number = 30;
-  zoom_min: number = .001;
-  zoom_step: number = .004;
+  zoom_min: number = .015;
+  zoom_step: number = .002;
   zoom_table: Array<number> = [];
 
   zoom_table_ndx_mixer: number = defaults.zoom_ndx_mixer;

--- a/src/app/core/provider/zoom.service.ts
+++ b/src/app/core/provider/zoom.service.ts
@@ -147,7 +147,6 @@ export class ZoomService {
   }
 
   setMixerIndexFromZoomValue(zoom: number){
-    console.log("SETTING TO ", zoom)
     let closest = this.zoom_table.reduce((acc, val, ndx) => {
       let diff = zoom - val;
       if(diff >= 0 && diff < acc.min) return {min: diff, ndx: ndx}
@@ -156,7 +155,7 @@ export class ZoomService {
     }, {min: 1000000, ndx: 0})
 
     this.zoom_table_ndx_mixer=  closest.ndx;
-    console.log("SET TO ", this.zoom_table_ndx_mixer, this.zoom_table[this.zoom_table_ndx_mixer])
+    // console.log("SET TO ", this.zoom_table_ndx_mixer, this.zoom_table[this.zoom_table_ndx_mixer])
 
   }
 

--- a/src/app/core/provider/zoom.service.ts
+++ b/src/app/core/provider/zoom.service.ts
@@ -65,30 +65,10 @@ export class ZoomService {
    */
   zoomToFitMixer(bounds: Bounds, viewable: {width: number, height: number}){
 
-    let factor = 1;
-
-    console.log("BOUNDS ", bounds, viewable);
-    //get the constraining dimension from the viewable; 
-   
-    if(viewable.width > viewable.height){
-        //constrained by height
-        factor = viewable.height / bounds.height;
-        console.log('CONSTRAINED BY HEIGHT', factor)
-
-        // let res_width = objs.width * factor;
-        // if(res_width > viewable.height){
-        //   factor = objs.width/ viewable.width;
-        // }
-
-    }else{
-      factor = bounds.width / viewable.width;
-
-      let res_height = bounds.height * factor;
-      if(res_height > viewable.height){
-        factor = bounds.height/ viewable.height;
-      }
-    }
-    this.setMixerIndexFromZoomValue(factor);
+    const w_factor = viewable.width / bounds.width;
+    const h_factor = viewable.height / bounds.height;
+    const smaller = Math.min(w_factor, h_factor)
+    this.setMixerIndexFromZoomValue(smaller);
 
 
   }

--- a/src/app/mixer/mixer.component.ts
+++ b/src/app/mixer/mixer.component.ts
@@ -255,19 +255,6 @@ addOp(event: any){
   this.palette.addOperation(event)
 }
 
-
-zoomIn(){
-  this.zs.zoomInMixer();
-  this.renderChange();
-
-}
-
-
-zoomOut(){
-  this.zs.zoomOutMixer();
-  this.renderChange();
-}
-
 createNewDraft(){
 
   const dialogRef = this.dialog.open(BlankdraftModal, {

--- a/src/app/mixer/palette/note/note.component.html
+++ b/src/app/mixer/palette/note/note.component.html
@@ -6,6 +6,7 @@ class="note-container selectable-{{!disable_drag}}"
 id="note-{{note.id}}"
 [style.background]="note.color"
 cdkDrag
+(cdkDragStarted)="dragStart($event)"
 (cdkDragMoved)="dragMove($event)">
 
 

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -491,11 +491,7 @@ export class OperationComponent implements OnInit {
 
 
     this.offset = null;
-    let op_container = document.getElementById('scale-'+this.id);
-    let rect_op = op_container.getBoundingClientRect();
-
-    console.log("DRAG START ", $event )
-
+  
      if(this.multiselect.isSelected(this.id)){
       this.multiselect.setRelativePosition(this.topleft);
      }else{
@@ -516,7 +512,6 @@ export class OperationComponent implements OnInit {
 
     let parent = document.getElementById('scrollable-container');
     let op_container = document.getElementById('scale-'+this.id);
-    let rect_op = op_container.getBoundingClientRect();
     let rect_palette = parent.getBoundingClientRect();
 
 
@@ -542,7 +537,7 @@ export class OperationComponent implements OnInit {
         x: scaled_pointer.x - op_topleft_inscale.x,
         y: scaled_pointer.y - op_topleft_inscale.y
       }
-      console.log("LEFT WITH SCALE VS, LEFT POINTER ", op_topleft_inscale, scaled_pointer, this.offset);
+      //console.log("LEFT WITH SCALE VS, LEFT POINTER ", op_topleft_inscale, scaled_pointer, this.offset);
 
     }
 

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -512,7 +512,7 @@ export class OperationComponent implements OnInit {
   dragMove($event: CdkDragMove) {
 
 
-    //GET THE LOCATION OF HTE POINTER RELATIVE TO THE TOP LEFT OF THE NODE
+    //GET THE LOCATION OF THE POINTER RELATIVE TO THE TOP LEFT OF THE NODE
 
     let parent = document.getElementById('scrollable-container');
     let op_container = document.getElementById('scale-'+this.id);
@@ -522,11 +522,13 @@ export class OperationComponent implements OnInit {
 
     const zoom_factor =  1/this.zs.getMixerZoom();
     
+    //this gives the position of
     let op_topleft_inscale = {
       x: op_container.offsetLeft,
       y: op_container.offsetTop
     }
 
+    
     let scaled_pointer = {
       x: ($event.pointerPosition.x-rect_palette.x + parent.scrollLeft) * zoom_factor,
       y: ($event.pointerPosition.y-rect_palette.y+ parent.scrollTop) * zoom_factor,
@@ -543,20 +545,6 @@ export class OperationComponent implements OnInit {
       console.log("LEFT WITH SCALE VS, LEFT POINTER ", op_topleft_inscale, scaled_pointer, this.offset);
 
     }
-
-  
-    // let screenX = $event.pointerPosition.x-rect_palette.x+parent.scrollLeft; 
-    // let scaledX = screenX* zoom_factor; //convert to scaled units
-    // let screenY = $event.pointerPosition.y-rect_palette.y+parent.scrollTop;
-    // let scaledY = screenY * zoom_factor;
-   
-    // let screenX = $event.pointerPosition.x-rect_palette.x-this.offset.x; 
-    // let scaledX = screenX* zoom_factor; //convert to scaled units
-    // let screenY = $event.pointerPosition.y-rect_palette.y-this.offset.y;
-    // let scaledY = screenY * zoom_factor;
-   
-
-    // console.log("SCREEN X and Y ", screenX, screenY)
 
 
     this.topleft = {

--- a/src/app/mixer/palette/palette.component.html
+++ b/src/app/mixer/palette/palette.component.html
@@ -1,4 +1,5 @@
 <div id="palette-scale-container">
+<canvas class="palette_base"></canvas>
 <ng-container #vc>
     <svg id="scratch_svg">
     

--- a/src/app/mixer/palette/palette.component.scss
+++ b/src/app/mixer/palette/palette.component.scss
@@ -1,6 +1,13 @@
 #palette-scale-container{
+    width: 100%;
+    height: 100%;
+    border: thin solid black;
+}
+
+.palette_base{
     width: 64000px;
     height: 64000px;
+    background-color: blueviolet;
 }
 
 svg{

--- a/src/app/mixer/palette/palette.component.scss
+++ b/src/app/mixer/palette/palette.component.scss
@@ -1,13 +1,11 @@
 #palette-scale-container{
     width: 100%;
     height: 100%;
-    border: thin solid black;
 }
 
 .palette_base{
     width: 64000px;
     height: 64000px;
-    background-color: blueviolet;
 }
 
 svg{

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -359,13 +359,24 @@ handlePan(diff: Point){
     /**TO DO  */
     //figure out how to keep the content centered when this zoom takes place
 
-    const container: HTMLElement = document.getElementById('palette-scale-container');
+
+    const view_window:HTMLElement = document.getElementById('scrollable-container');
+    const container:HTMLElement = document.getElementById('palette-scale-container');
+    if(view_window === null || view_window === undefined) return;
+
+    //let the top left point of the scroll, this is given in terms of palette scale container. 
+
+
+    console.log("ZOOMS BEFORE/NOW", container.style.transform, this.zs.getMixerZoom())
     if(container === null) return;
 
     // const scrollTop = container.parentElement.scrollTop;
     // const scrollLeft = container.parentElement.scrollLeft;
     container.style.transformOrigin = 'top left';
     container.style.transform = 'scale(' + this.zs.getMixerZoom() + ')';
+
+    //consider adjusting scroll to the new 
+ 
 
     this.redrawConnections();
   }

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -345,9 +345,9 @@ handlePan(diff: Point){
     
 }
 
-  // centerView(){
-  //   this.rescale();
-  // }
+  centerView(){
+    this.rescale();
+  }
 
 
 

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -345,38 +345,48 @@ handlePan(diff: Point){
     
 }
 
-  centerView(){
-    this.rescale();
-  }
+  // centerView(){
+  //   this.rescale();
+  // }
 
 
 
   /**
-   * @param scale 
+   * updates the view after a zoom event is called. Changes the scale of the palette scale container and 
+   * scrolls such that the top left point when zoom is called remains the same after the zoom is updated
+   * 
+   * the position of the operation does not change, only the scale does. 
    */
   rescale(){
-
-    /**TO DO  */
-    //figure out how to keep the content centered when this zoom takes place
-
 
     const view_window:HTMLElement = document.getElementById('scrollable-container');
     const container:HTMLElement = document.getElementById('palette-scale-container');
     if(view_window === null || view_window === undefined) return;
 
     //let the top left point of the scroll, this is given in terms of palette scale container. 
-
-
-    console.log("ZOOMS BEFORE/NOW", container.style.transform, this.zs.getMixerZoom())
     if(container === null) return;
 
-    // const scrollTop = container.parentElement.scrollTop;
-    // const scrollLeft = container.parentElement.scrollLeft;
-    container.style.transformOrigin = 'top left';
-    container.style.transform = 'scale(' + this.zs.getMixerZoom() + ')';
+    // //what % of the range is this point 
+    let pcentX = view_window.scrollLeft / view_window.scrollWidth;
+    let pcentY = view_window.scrollTop / view_window.scrollHeight;
 
-    //consider adjusting scroll to the new 
- 
+
+    //transform to the top left 
+    //container.style.transformOrigin = scrollLeft+"px "+scrollTop+"px"; //this goes to the center point
+    container.style.transformOrigin = "top left"; //reset after moving as to not affect scrolling 
+    container.style.transform = 'scale(' + this.zs.getMixerZoom() + ')'; 
+
+
+    // move the scroll by the same % within the new div size
+    let newScrollLeft =  view_window.scrollWidth * pcentX;
+    let newScrollTop =  view_window.scrollWidth * pcentY;
+
+
+    view_window.scroll({
+      left: newScrollLeft,
+      top: newScrollTop,
+      behavior: "instant"
+    });
 
     this.redrawConnections();
   }


### PR DESCRIPTION
resolves #216, resolves #180, resolves part of issue #214 (part 3)

Made several improvements to the view controls: 

**1. Zoom To Fit**
Responded to neon22's request to add a zoom to fit feature that can (a) adjust zoom and scroll such that all notes and operations/drafts are visible and (b) adjust zoom and scroll such that the view is zoomed into the selected components. 

<img width="430" alt="Screenshot 2025-01-26 at 4 22 16 PM" src="https://github.com/user-attachments/assets/ebf4538e-86b6-412f-b4ee-75a5aaf7030e" />

Clicking the "focus" button will make sure all of the components fit within the current view window. 
<img width="679" alt="Screenshot 2025-01-26 at 4 30 21 PM" src="https://github.com/user-attachments/assets/824aa2c2-e936-4927-b792-6d6b50ed254d" />

**2. Maintain View in Zoom In/Out**

Currently, when you zoomed in and out it would do this from the origin at the top left of the palette. Now, it does the same thing but adjusts scroll so that whatever point was the top left when you hit zoom will remain the top left point. 

**3. Drag without Snapping to Top Left of Components.** 

Backstory: Angular's default Drag and Drop controller does not support the scaled div upon which dragging is taking place. As a result, I translate the mouse point to the scaled space of the palette and then manually set the top left of the component to that point. This meant that the component was always "snapping" to the top left, no matter where in the component you clicked. I updated this behavior such that the point where you click in the component remains the point from which you move the component. I made this work for both operations, drafts, and notes. 



