### PR TITLE
210 right click options + bug fixes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1654,7 +1654,8 @@ redo() {
         utilInstance.saveAsBmp(b, draft, this.ws.selected_origin_option, this.ms, this.fs)
         break;
       case 'jpg':
-        utilInstance.saveAsPrint(b, draft, true, this.ws.selected_origin_option, this.ms, this.sys_serve, this.fs)
+        let visvars = this.viewer.getVisVariables();
+        utilInstance.saveAsPrint(b, draft, visvars.use_floats, visvars.use_colors, this.ws.selected_origin_option, this.ms, this.sys_serve, this.fs)
         break;
       case 'wif':
         let loom = this.tree.getLoom(this.vs.getViewer() );

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -124,7 +124,6 @@ export class AppComponent implements OnInit{
     private zone: NgZone
   ){
 
-    console.log("OP COMPONENT CONSTRUCTED")
 
     this.current_version = this.vers.currentVersion();
   
@@ -163,7 +162,6 @@ export class AppComponent implements OnInit{
 
 
   ngOnInit(){
-    console.log("OP COMPONENT INIT")
 
     this.filename_form = new UntypedFormControl(this.files.getCurrentFileName(), [Validators.required]);
     this.filename_form.valueChanges.forEach(el => {this.renameWorkspace(el.trim())})
@@ -188,7 +186,6 @@ export class AppComponent implements OnInit{
 
 
   ngAfterViewInit() {
-    console.log("OP COMPONENT After INit")
 
     this.recenterViews();
   }
@@ -267,7 +264,6 @@ export class AppComponent implements OnInit{
 
   toggleEditorMode(){
 
-    console.log("ON TOGGLE ", this.selected_editor_mode)
     switch(this.selected_editor_mode){
       case 'draft':
 
@@ -287,7 +283,6 @@ export class AppComponent implements OnInit{
           this.generateBlankDraftAndPlaceInMixer(obj, 'toggle');
 
         }else{
-          console.log("LOADING ", this.vs.getViewer())
           this.editor.loadDraft(this.vs.getViewer());
           this.editor.onFocus(); 
         }
@@ -464,7 +459,7 @@ export class AppComponent implements OnInit{
    * @param user 
    */
   initLoginLogoutSequence(user:User) {
-    console.log("IN LOGIN/LOGOUT ", user)
+    console.log("IN LOGIN/LOGOUT ")
     /** TODO: check also if the person is online */
 
 
@@ -1220,17 +1215,14 @@ async processFileData(data: FileObj) : Promise<string|void>{
 
   })
   .then(el => {
-      console.log("VALIDATE NODES")
       return this.tree.validateNodes();
   })
   .then(el => {
     //console.log("performing top level ops");
-    console.log("PERFORM TOP LEVEL NODES")
       return  this.tree.performTopLevelOps();
   })
   .then(el => {
     //delete any nodes that no longer need to exist
-    console.log("DELETE UNNEEDED NODES")
 
     this.tree.getDraftNodes()
     .filter(el => el.draft === null)
@@ -1244,7 +1236,6 @@ async processFileData(data: FileObj) : Promise<string|void>{
     })
   })
   .then(el => {
-    console.log("LOADING UI")
 
     return this.tree.nodes.forEach(node => {
       
@@ -1303,24 +1294,14 @@ async processFileData(data: FileObj) : Promise<string|void>{
 
   })
   .then(res => {    
-    console.log("RENDER")
 
     this.loading = false;
-    console.log("UPDATE ORIGIN")
     this.updateOrigin(this.ws.selected_origin_option);
 
-    console.log("MIXER REFRESH OPERATIONS")
     this.mixer.refreshOperations();
-
-    console.log("MIXER REnder Change")
-
     this.mixer.renderChange();
-    console.log("MIXER REnder Change")
-
     this.editor.renderChange();
-    console.log("Editor REnder Change")
 
-    console.log("THE TREE ", this.tree.nodes)
 
 
     return Promise.resolve('alldone')

--- a/src/app/core/modal/welcome/welcome.component.html
+++ b/src/app/core/modal/welcome/welcome.component.html
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="left">
      Want to learn more about AdaCAD 4?
-      <button mat-raised-button cdkFocusInitial mat-dialog-close color="primary" (click)="loadDocs()">Browse the Documentation</button>
+      <button mat-raised-button (click)="loadDocs()">Browse the Documentation</button>
 
     </div>
     <div class="right">
@@ -19,6 +19,6 @@
 
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button mat-dialog-close >Close</button>
+  <button mat-button cdkFocusInitial color="primary" mat-dialog-close >Close</button>
 </mat-dialog-actions>
 

--- a/src/app/core/model/drafts.ts
+++ b/src/app/core/model/drafts.ts
@@ -427,7 +427,6 @@ export const createDraft = (
    */
   export const getDraftAsImage = (draft: Draft, pix_per_cell: number, floats: boolean, use_color: boolean, mats: Array<Material>) : ImageData => {
 
-
     pix_per_cell = Math.floor(pix_per_cell);
 
     const warp_num = warps(draft.drawdown)

--- a/src/app/core/model/util.ts
+++ b/src/app/core/model/util.ts
@@ -1173,7 +1173,7 @@ async saveAsWif(fs: FileService, draft: Draft, loom:Loom, loom_settings:LoomSett
   
 }
 
-async saveAsPrint(el: any, draft: Draft, use_colors: boolean, selected_origin_option: number, ms: MaterialsService, ss: SystemsService, fs: FileService ) {
+async saveAsPrint(el: any, draft: Draft, floats: boolean, use_colors: boolean, selected_origin_option: number, ms: MaterialsService, ss: SystemsService, fs: FileService ) {
 
   let b = el;
   let context = b.getContext('2d');
@@ -1256,7 +1256,7 @@ let system = null;
 
 
     }
-  let img = getDraftAsImage(draft, 10, true, use_colors, ms.getShuttles());  
+  let img = getDraftAsImage(draft, 10, floats, use_colors, ms.getShuttles());  
   context.putImageData(img, 30, 30);
 
   context.font = "12px Arial";

--- a/src/app/core/provider/file.service.ts
+++ b/src/app/core/provider/file.service.ts
@@ -59,9 +59,7 @@ export class FileService {
 
      ada: async (filename: string, src: string, id: number, desc: string, data: any,  from_share: string) : Promise<LoadResponse> => {
 
-    
-      console.log("LOADER CALLED")
-
+  
       if(desc === undefined) desc = ""
       if(filename == undefined) filename = 'draft' 
       if(from_share == undefined) from_share = '' 
@@ -116,7 +114,6 @@ export class FileService {
         if(draft_nodes == undefined) draft_nodes = [];
 
         if(draft_nodes !== undefined){
-          console.log("DRAFT NOTES IS ", draft_nodes)
 
           draft_nodes.forEach(el => {
 
@@ -151,7 +148,6 @@ export class FileService {
           const loom = data.looms.find(loom => loom.draft_id === node.node_id);
           const draft = data.drafts.find(draft => draft.id === node.node_id);
 
-          console.log("LOADING DRAFT NODE", node, draft)
 
           const dn: DraftNodeProxy = {
             node_id: (node === undefined) ? -1 : node.node_id,

--- a/src/app/core/provider/version.service.ts
+++ b/src/app/core/provider/version.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 })
 export class VersionService {
 
-  private version: string = '4.2.11'
+  private version: string = '4.2.12'
 
 
   constructor() { 

--- a/src/app/core/ui/draft-rendering/draft-rendering.component.ts
+++ b/src/app/core/ui/draft-rendering/draft-rendering.component.ts
@@ -198,12 +198,14 @@ export class DraftRenderingComponent implements OnInit {
         
   }
 
-  ngOnChanges(changes:SimpleChanges){
-    if (changes['scale']) {
-     if(!changes['scale'].isFirstChange() && this.tree.getDraftVisible(this.id)) this.redrawAll();
-    }
+  //THIS DETECTS AND REDRAWS WHEN IT DOESN"T NEED TO 
+  //ngOnChanges(changes:SimpleChanges){
+    // console.log("CHANGES ", changes)
+    // if (changes['scale']) {
+    //  if(!changes['scale'].isFirstChange() && this.tree.getDraftVisible(this.id)) this.redrawAll();
+    // }
 
-  }
+  //}
   
 
   
@@ -925,17 +927,17 @@ export class DraftRenderingComponent implements OnInit {
       * receives offset of the scroll from the CDKScrollable created when the scroll was initiated
       */
       //this does not draw on canvas but just rescales the canvas
-      // public rescale(scale: number){
+      public rescale(scale: number){
         
-      //   if(this.id == -1) return;
+        if(this.id == -1) return;
 
-      //     const draft = this.tree.getDraft(this.id);
-      //     const loom = this.tree.getLoom(this.id);
-      //     const loom_settings = this.tree.getLoomSettings(this.id);
-      //     this.render.rescale(draft, loom, loom_settings, scale, this.canvases);
+          const draft = this.tree.getDraft(this.id);
+          const loom = this.tree.getLoom(this.id);
+          const loom_settings = this.tree.getLoomSettings(this.id);
+          this.render.rescale(draft, loom, loom_settings, scale, this.canvases);
 
            
-      // }
+      }
       
       
       

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -494,6 +494,11 @@ export class EditorComponent implements OnInit {
   renderChange(){
     //the renderer is listening for changes to scale and will redraw
     this.scale = this.zs.getEditorZoom();
+    this.weaveRef.scale = this.scale
+    // this.weaveRef.rescale(this.scale);
+
+    //we have to redraw for now so that UI div buttons line up with scaled view
+    this.redraw();
   }
         
         

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
@@ -345,7 +345,7 @@ export class DraftContainerComponent implements AfterViewInit{
         this.local_zoom = event;
         const dn = <DraftNode> this.tree.getNode(this.id);
         dn.scale = this.local_zoom;
-        this.draft_rendering.redrawAll();
+        this.draft_rendering.rescale(dn.scale);
     }
   
 

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
@@ -289,13 +289,15 @@ export class DraftContainerComponent implements AfterViewInit{
   async saveAsPrint() {
     let draft = this.tree.getDraft(this.id);
 
-    
-
+    console.log("CURRENT VIEW ", this.current_view)
+    let floats = (this.current_view == 'draft') ? false : true;
+    let color = (this.current_view == 'visual') ? true : false;
 
     utilInstance.saveAsPrint(
       this.bitmap.nativeElement,
       draft,
-      this.use_colors,
+      color,
+      floats,
       this.ws.selected_origin_option, 
       this.ms,
       this.ss,

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
@@ -50,7 +50,7 @@ export class DraftContainerComponent implements AfterViewInit{
 
   draft_visible: boolean = true;
 
-  use_colors: boolean = false;
+  use_colors: boolean = true;
 
   outlet_connected: boolean = true;
 
@@ -288,6 +288,9 @@ export class DraftContainerComponent implements AfterViewInit{
 
   async saveAsPrint() {
     let draft = this.tree.getDraft(this.id);
+
+    
+
 
     utilInstance.saveAsPrint(
       this.bitmap.nativeElement,

--- a/src/app/mixer/palette/operation/operation.component.html
+++ b/src/app/mixer/palette/operation/operation.component.html
@@ -76,12 +76,34 @@ cdkDrag
           <i class="fa-solid fa-circle-info"></i> help
           </button> 
 
+          <button  mat-menu-item
+          (click)="saveAsBmp()"
+          matTooltip ="Download as Bitmap">
+          <i class="fa-solid fa-download"></i> download as bitmap
+          </button>
+    
+          <button  mat-menu-item
+          (click)="saveAsPrint()"
+          matTooltip ="Download as Printable Image">
+          <i class="fa-solid fa-image"></i> download as image
+          </button>
+    
+          <button  mat-menu-item
+          (click)="saveAsWif()"
+          matTooltip ="Download as .WIF file">
+          <i class="fa-solid fa-file"></i> download as .WIF file
+          </button>
+
           <button 
           mat-menu-item
           (click)="delete()">
           <i class="fa-solid fa-times"></i> delete  
   
           </button>
+
+          
+         
+    
         
         </mat-menu>
        

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -269,6 +269,32 @@ export class OperationComponent implements OnInit {
   }
 
 
+  /**
+   * TO DO - right now, this defalts to the first child, if there are multiple children, does not offer a way to select...figure that part out
+   */
+  async saveAsWif() {
+
+    if(this.draftContainers.length > 0){
+      this.draftContainers.get(0).saveAsWif();
+    }
+  
+  }
+
+  async saveAsPrint() {
+    if(this.draftContainers.length > 0){
+      this.draftContainers.get(0).saveAsPrint();
+    }
+  }
+
+  async saveAsBmp() : Promise<any> {
+    if(this.draftContainers.length > 0){
+      this.draftContainers.get(0).saveAsBmp();
+    }
+   
+  }
+
+
+
 
   unpinFromView(){
     this.vs.clearPin();

--- a/src/app/viewer/simulation/simulation.component.ts
+++ b/src/app/viewer/simulation/simulation.component.ts
@@ -69,7 +69,6 @@ export class SimulationComponent implements OnInit {
 
 
   ngAfterViewInit(){
-    console.log("START SIM")
     
     const parent_div = document.getElementById('static_draft_view');
     const parent_rect = parent_div.getBoundingClientRect();

--- a/src/app/viewer/viewer.component.html
+++ b/src/app/viewer/viewer.component.html
@@ -129,7 +129,7 @@
               [max]="zs.num_steps"  
               step="1" 
              >
-              <input matSliderThumb [(ngModel)]="zs.zoom_table_ndx_viewer"  (valueChange)="renderChange()" >
+              <input matSliderThumb [(ngModel)]="zs.zoom_table_ndx_viewer"  (valueChange)="zoomChange()" >
             </mat-slider>
 
       

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -174,11 +174,15 @@ getVisVariables(){
 
   //when expanded, someone can set the zoom from the main zoom bar
   //this is called, then, to rescale the view
-  renderChange(){
+  zoomChange(){
+    
+
+    if(this.id == -1) return;
     this.scale = this.zs.getViewerZoom();
     this.view_rendering.scale = this.scale;
-    if(this.id == -1) return;
-    this.drawDraft(this.id);
+    this.view_rendering.rescale(this.scale);
+    //TO DO re-enable this but figure out where it is being called from
+    //this.drawDraft(this.id);
   }
 
   /**
@@ -204,7 +208,7 @@ getVisVariables(){
     let flags =  {
       drawdown: true, 
       use_colors: (this.vis_mode == 'color'),
-      use_floats: (this.vis_mode != 'draft'), 
+      use_floats: (this.vis_mode !== 'draft'), 
       show_loom: false
     }
 


### PR DESCRIPTION
streamlined options on operations and drafts so that you can double click to the same option menu. Known bug if the operation has more than one draft in that download will always just pick the first one. You can get around this (for now) by clicking download from the viewer instead of the operation. In the future, maybe we can have a menu that lets you pick which draft you want to download but the number of cases for this are small. 

I also found a bug where download image downloaded an image that was not the same as the current view. I streamlined it so now it will download the current view. 

Also fixed a bug where the view mode in the viewer would always go back after you rescaled. This was due to an errant OnChanges event in the rendere that would redraw with scale. I removed this call, and others that called redraw on scale, to speed up the redraws. I left the editor as is, as it's more complicated with the add/clone/delete row functions with different zooms. 