### PR TITLE
214 structure gui improvements beta427

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -172,10 +172,10 @@ export class AppComponent implements OnInit{
     //   items: [{ uid: this.auth.uid }]
     // });
 
-    let dialogRef = this.dialog.open(WelcomeComponent, {
-      height: '400px',
-      width: '600px',
-    });
+    // let dialogRef = this.dialog.open(WelcomeComponent, {
+    //   height: '400px',
+    //   width: '600px',
+    // });
 
   
 

--- a/src/app/core/provider/version.service.ts
+++ b/src/app/core/provider/version.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 })
 export class VersionService {
 
-  private version: string = '4.2.12'
+  private version: string = '4.2.13'
 
 
   constructor() { 

--- a/src/app/mixer/palette/operation/operation.component.html
+++ b/src/app/mixer/palette/operation/operation.component.html
@@ -1,7 +1,6 @@
 <div id='scale-{{id}}' class="operation-parent no-text-select selectable-{{!disable_drag}}"
 cdkDrag
 (mousedown)="mousedown($event)"
-(dblclick)="onDoubleClick()"
 (click)='toggleSelection($event)' 
 [style.z-index] = "zndx"
 (cdkDragMoved)="dragMove($event)"
@@ -14,7 +13,7 @@ cdkDrag
 
 
   <div class="operation-container" [style.background-color]="opdescriptions.getCatColor(category_name)">
-        <div class="cxn-row" cdkDragHandle>
+        <div class="cxn-row" cdkDragHandle >
             <div  *ngFor="let input of opnode.inlets; let i = index" class="input-group">
               
               <app-inlet 
@@ -32,7 +31,8 @@ cdkDrag
         </div>
 
 
-        <div class="top-row" cdkDragHandle>
+        <div class="top-row " (dblclick)="onDoubleClick($event)"
+ cdkDragHandle>
 
         <div class="operation-details">
             <div class="name no-text-select">{{displayname}}</div>
@@ -144,7 +144,7 @@ cdkDrag
       </div>
 
 
-      <div class="outputs">
+      <div class="outputs" (dblclick)="onDoubleClick($event)">
         <app-draftcontainer class="draftrendering from_operation" 
         *ngFor="let child_id of children" 
         [id]="child_id" 

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -190,7 +190,7 @@ export class OperationComponent implements OnInit {
     e.stopPropagation();
   }
 
-  onDoubleClick(){
+  onDoubleClick(event: any){
     this.trigger.openMenu();
   }
 

--- a/src/app/mixer/palette/operation/parameter/parameter.component.html
+++ b/src/app/mixer/palette/operation/parameter/parameter.component.html
@@ -1,5 +1,4 @@
     
-
     <ng-container  *ngIf="param.type === 'number'">
         
       <div class="number_input">

--- a/src/app/mixer/palette/subdraft/subdraft.component.html
+++ b/src/app/mixer/palette/subdraft/subdraft.component.html
@@ -5,7 +5,6 @@
 	class="subdraft-parent-container selectable-{{!disable_drag}}" 
 	[class.is_selected]="selected_draft_id == id"
 	cdkDrag
-	(dblclick)="onDoubleClick()"
 	(click)="toggleMultiSelection($event)"
 	[style.z-index] = "zndx"
 	[class.no-pointer] = "disable_drag"
@@ -15,7 +14,10 @@
 	(cdkDragStarted)="dragStart($event)"
 	> 
 
- 	<div class="topbar" cdkDragHandle >
+ 	<div class="topbar" 	
+	(dblclick)="onDoubleClick()"
+ 	cdkDragHandle 
+	>
 	</div>
 
 


### PR DESCRIPTION
Closes #214 

Made double clicks only register on areas of an operation or draft that are not otherwise editable. In seed drafts, this means you can only double click to open the menu by clicking the black header bar. 

Also removed the "welcome popup" now that AdaCAD 4 has been live for a few months. 