### PR TITLE
249 draft editor not working

### DIFF
--- a/src/app/core/operations/layer/layer.ts
+++ b/src/app/core/operations/layer/layer.ts
@@ -42,7 +42,7 @@ const  perform = (op_params: Array<OpParamVal>, op_inputs: Array<OpInput>) : Pro
    let composite = new Sequence.TwoD().setBlank(2
     );
    let ends = utilInstance.lcm(drafts.map(el => warps(el.drawdown))) * drafts.length;
-   let pics = utilInstance.lcm(drafts.map(el => warps(el.drawdown))) * drafts.length;
+   let pics = utilInstance.lcm(drafts.map(el => wefts(el.drawdown))) * drafts.length;
 
 
   

--- a/src/app/core/provider/version.service.ts
+++ b/src/app/core/provider/version.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 })
 export class VersionService {
 
-  private version: string = '4.3.0'
+  private version: string = '4.3.1'
 
 
   constructor() { 

--- a/src/app/core/ui/filebrowser/filebrowser.component.html
+++ b/src/app/core/ui/filebrowser/filebrowser.component.html
@@ -182,7 +182,7 @@ cdkDrag
                 </mat-form-field>
 
 
-                <h4 *ngIf="rename_mode_id !== file.id" >  {{file.meta.name}} {{file.id}}</h4>
+                <h4 *ngIf="rename_mode_id !== file.id" >  {{file.meta.name}}</h4>
 
 
 

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -115,9 +115,16 @@ export class EditorComponent implements OnInit {
 
 
     updateWeavingInfo(){
+
+
       const loom = this.tree.getLoom(this.id);
       const draft = this.tree.getDraft(this.id);
       const loom_settings = this.tree.getLoomSettings(this.id);
+
+      if(loom == null || draft == null || loom_settings == null) return;
+
+      console.log("Update Vewing Info", loom, draft, loom_settings)
+
       let utils = getLoomUtilByType(loom_settings.type);
       this.dressing_info = utils.getDressingInfo(draft.drawdown, loom, loom_settings);
 

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -355,7 +355,9 @@ export class OperationComponent implements OnInit {
 
   openHelpDialog() {
 
-    window.open('https://docs.adacad.org/docs/reference/operations/'+this.op.name, '_blank');
+    let regex = new RegExp(' ', 'g');
+    let op_name_format = this.op.name.replace(regex, '_');
+    window.open('https://docs.adacad.org/docs/reference/operations/'+op_name_format, '_blank');
 ;
 
   }


### PR DESCRIPTION
Minor fixes: 

1. Closes #249 by checking for null before generating weaving info. More work to do here understanding why those values are null, but this at least prevents the crashing. 
2. Fixes help link error suggested on Discord but replacing op names with spaces to underscores for URLs. 
3. Removed file ids from browser (a left over from prior debugging). 
4. Updated version to 4.3.1