### PR TITLE
updated version and fixed seed draft reload error

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1346,15 +1346,16 @@ async processFileData(data: FileObj) : Promise<string|void>{
   })
   .then(id_map => {
       entry_mapping = id_map;
-    //  console.log(" LOAD TREE Nodes")
+      // console.log(" LOADED TREE Nodes ", this.tree.nodes, id_map)
       return this.loadTreeNodes(id_map, data.treenodes);
     }
   ).then(treenodes => {
-
+    // console.log("TREE NODES is ", data.treenodes)
     const seednodes: Array<{prev_id: number, cur_id: number}> = treenodes
       .filter(tn => this.tree.isSeedDraft(tn.tn.node.id))
       .map(tn => tn.entry);
     
+    // console.log("SEED NODES ARE ", seednodes)
     const seeds: Array<{entry, id, draft, loom, loom_settings, render_colors, scale, draft_visible}> = seednodes
     .map(sn =>  {
 

--- a/src/app/core/model/drafts.ts
+++ b/src/app/core/model/drafts.ts
@@ -223,12 +223,16 @@ export const createDraft = (
   export const loadDraftFromFile = (data: any, version: string, src: string) : Promise<{draft: Draft, id: number}> => {
     const draft: Draft = initDraft();
 
-    // console.log("DATA is ", data)
+     console.log("DATA is ", data)
+    
 
     if(data.id !== undefined) draft.id = data.id;
+
     draft.gen_name = (data.gen_name === undefined) ? 'draft' : data.gen_name;
     draft.ud_name = (data.ud_name === undefined) ? '' : data.ud_name;
     
+
+
     if(version === undefined || version === null || !utilInstance.sameOrNewerVersion(version, '3.4.5')){
       draft.drawdown = parseSavedDrawdown(data.pattern);
     }else{

--- a/src/app/core/provider/file.service.ts
+++ b/src/app/core/provider/file.service.ts
@@ -59,6 +59,8 @@ export class FileService {
 
      ada: async (filename: string, src: string, id: number, desc: string, data: any,  from_share: string) : Promise<LoadResponse> => {
 
+      // console.log("IN LOADER ", data)
+
   
       if(desc === undefined) desc = ""
       if(filename == undefined) filename = 'draft' 
@@ -109,13 +111,20 @@ export class FileService {
       }
 
       if(utilInstance.sameOrNewerVersion(version, '3.4.5')){
+    
         draft_nodes = data.draft_nodes;
-
         if(draft_nodes == undefined) draft_nodes = [];
 
         if(draft_nodes !== undefined){
 
           draft_nodes.forEach(el => {
+
+            if(el.draft_id !== el.node_id){
+              el.draft_id = el.node_id;
+              if(el.draft !== null && el.draft !== undefined) el.draft.id = el.node_id;
+
+              if(el.compressed_draft !== null && el.compressed_draft !== undefined) el.compressed_draft.id = el.node_id;
+            }
 
             if(el.draft == undefined && el.compressed_draft !== undefined && el.compressed_draft !== null){
               draft_fns.push(loadDraftFromFile(el.compressed_draft, version, src));
@@ -131,7 +140,8 @@ export class FileService {
             }
 
          
-        
+
+
           });
        }
         
@@ -522,12 +532,10 @@ export class FileService {
 
 
 
-    console.log("LOOM TYPE IS ",  loom_settings.type)
      if(loom === null){
 
       //force loom type to something with shafts;
       loom_settings.type = 'frame';
-      console.log("LOOM WAS NULL in saver")
       loom = await getLoomUtilByType(loom_settings.type).computeLoomFromDrawdown(draft.drawdown, loom_settings);
 
      }

--- a/src/app/core/provider/version.service.ts
+++ b/src/app/core/provider/version.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 })
 export class VersionService {
 
-  private version: string = '4.3.1'
+  private version: string = '4.3.2'
 
 
   constructor() { 


### PR DESCRIPTION
I was serendipitously able to reproduce the error in a testable way and discovered that it related to cases where the node-id and the draft-id were not the same (as I assume they should be). I fixed this by doing a check in file.service.js on the ada loader that checks for these mis-matches and, if located, updates the draft id (and related instances of that id) to match the node id. This seems to have fixed the error. 