### PR TITLE
252 pass through

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1520,7 +1520,6 @@ async processFileData(data: FileObj) : Promise<string|void>{
     this.editor.renderChange();
 
 
-
     return Promise.resolve('alldone')
   })
   .catch(e => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1488,7 +1488,9 @@ async processFileData(data: FileObj) : Promise<string|void>{
       const new_id = entry_mapping.find(el => el.prev_id === np.node_id);
       const node = this.tree.getNode(new_id.cur_id);
       if(node === undefined) return;
-      (<DraftNode> node).draft.ud_name = np.draft_name;
+    
+      (<DraftNode> node).draft.gen_name = np.gen_name;
+      (<DraftNode> node).draft.ud_name = np.ud_name;
       (<DraftNode> node).loom_settings = np.loom_settings; 
       (<DraftNode> node).loom = copyLoom(np.loom); 
       if(np.render_colors !== undefined) (<DraftNode> node).render_colors = np.render_colors; 

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -59,6 +59,7 @@ import { MediaService } from './provider/media.service';
 import { OperationService } from './provider/operation.service';
 import { ShareComponent } from './modal/share/share.component';
 import { WorkspaceComponent } from './modal/workspace/workspace.component';
+import { RenameComponent } from './modal/rename/rename.component';
 
 
 
@@ -107,6 +108,7 @@ import { WorkspaceComponent } from './modal/workspace/workspace.component';
         LoginComponent,
         SignupComponent,
         BlankdraftModal,
+        RenameComponent,
         ExamplesComponent,
         LoadfileComponent,
         FilebrowserComponent,
@@ -173,7 +175,8 @@ import { WorkspaceComponent } from './modal/workspace/workspace.component';
         EventsDirective,
         DraftRenderingComponent,
         SelectionComponent,
-        ViewadjustComponent
+        ViewadjustComponent,
+        RenameComponent
              ]
 })
 export class CoreModule { }

--- a/src/app/core/modal/rename/rename.component.html
+++ b/src/app/core/modal/rename/rename.component.html
@@ -3,12 +3,16 @@
 
 <mat-dialog-content>
 
-    ud_name = {{ud_name}}
-    gen_name = {{gen_name}}
-  
-  <mat-form-field appearance="fill">
+    <div>ud name: {{ud_name}}</div>
+    <div>gen name: {{gen_name}}</div>
+    
+    <mat-form-field appearance="fill">
     <mat-label>Draft Name</mat-label>
+
+
+
     <input matInput (input)="change($event)" [placeholder]=gen_name [(ngModel)]="ud_name">
+    <mat-hint>changes are automatically saved</mat-hint>
   </mat-form-field>
     </mat-dialog-content>
 

--- a/src/app/core/modal/rename/rename.component.html
+++ b/src/app/core/modal/rename/rename.component.html
@@ -1,0 +1,19 @@
+  
+<h2 mat-dialog-title>Rename this Draft</h2>
+
+<mat-dialog-content>
+
+    ud_name = {{ud_name}}
+    gen_name = {{gen_name}}
+  
+  <mat-form-field appearance="fill">
+    <mat-label>Draft Name</mat-label>
+    <input matInput (input)="change($event)" [placeholder]=gen_name [(ngModel)]="ud_name">
+  </mat-form-field>
+    </mat-dialog-content>
+
+
+
+  <mat-dialog-actions>
+    <button mat-button mat-dialog-close>Close</button>
+  </mat-dialog-actions>

--- a/src/app/core/modal/rename/rename.component.html
+++ b/src/app/core/modal/rename/rename.component.html
@@ -3,17 +3,17 @@
 
 <mat-dialog-content>
 
-    <div>ud name: {{ud_name}}</div>
-    <div>gen name: {{gen_name}}</div>
-    
+
     <mat-form-field appearance="fill">
     <mat-label>Draft Name</mat-label>
 
 
 
     <input matInput (input)="change($event)" [placeholder]=gen_name [(ngModel)]="ud_name">
-    <mat-hint>changes are automatically saved</mat-hint>
-  </mat-form-field>
+    <mat-hint>changes will be automatically saved</mat-hint>
+    </mat-form-field>
+    
+
     </mat-dialog-content>
 
 

--- a/src/app/core/modal/rename/rename.component.spec.ts
+++ b/src/app/core/modal/rename/rename.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RenameComponent } from './rename.component';
+
+describe('RenameComponent', () => {
+  let component: RenameComponent;
+  let fixture: ComponentFixture<RenameComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RenameComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(RenameComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/modal/rename/rename.component.ts
+++ b/src/app/core/modal/rename/rename.component.ts
@@ -1,0 +1,39 @@
+import { Component, Inject, SimpleChanges } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatFormField } from '@angular/material/form-field';
+import { TreeService } from '../../provider/tree.service';
+import { Draft } from '../../model/datatypes';
+
+@Component({
+  selector: 'app-rename',
+  standalone: false,
+  templateUrl: './rename.component.html',
+  styleUrl: './rename.component.scss'
+})
+export class RenameComponent {
+
+  id: number;
+  ud_name: string;
+  gen_name: string;
+  draft:Draft = null
+ constructor(
+    private tree: TreeService, 
+    private dialogRef: MatDialogRef<RenameComponent>, 
+    @Inject(MAT_DIALOG_DATA) private data: any) {
+      
+      this.id = data.id;
+      this.draft = this.tree.getDraft(this.id);
+      this.ud_name = this.draft.ud_name;
+      this.gen_name = this.draft.gen_name; 
+
+      
+    
+    
+    }
+
+    change(event: SimpleChanges){
+      this.draft.ud_name = this.ud_name;
+      this.tree.setDraftOnly(this.id, this.draft);
+    }
+
+}

--- a/src/app/core/model/datatypes.ts
+++ b/src/app/core/model/datatypes.ts
@@ -329,7 +329,8 @@ export interface NodeComponentProxy{
    export interface DraftNodeProxy{
     node_id: number;
     draft_id: number;
-    draft_name: string;
+    ud_name: string;
+    gen_name:string;
     draft: Draft;
     compressed_draft: CompressedDraft;
     draft_visible: boolean;

--- a/src/app/core/model/drafts.ts
+++ b/src/app/core/model/drafts.ts
@@ -228,9 +228,17 @@ export const createDraft = (
 
     if(data.id !== undefined) draft.id = data.id;
 
-    draft.gen_name = (data.gen_name === undefined) ? 'draft' : data.gen_name;
-    draft.ud_name = (data.ud_name === undefined) ? '' : data.ud_name;
+    if(data.draft_name === undefined){
+      draft.gen_name = (data.gen_name === undefined) ? defaults.draft_name : data.gen_name;
+      draft.ud_name = (data.ud_name === undefined) ? '' : data.ud_name;
     
+    }else{
+      draft.gen_name = data.draft_name;
+      draft.ud_name = '';
+    
+      
+    }
+ 
 
 
     if(version === undefined || version === null || !utilInstance.sameOrNewerVersion(version, '3.4.5')){

--- a/src/app/core/model/util.ts
+++ b/src/app/core/model/util.ts
@@ -1274,6 +1274,54 @@ let system = null;
   
 }
 
+/**
+ * used by operations that parse a string input meant to represent a set of warp and weft systems. This checks if the systems input are valid in terms of the systems that draft will be using, 
+ * @param input_systems  {wesy: Array<string>, wasy: Array<string>}
+ * @param original_systems {wesy: Array<string>, wasy: Array<string>}
+ */
+makeValidSystemList(input_systems: any, original_systems: any) : any {
+
+  let formatted_systems = {
+    valid: true,
+    wesy: [],
+    wasy: []
+  }
+
+
+  if(input_systems.wesy.length != 0){
+  //at least one weft systems needs to be valid; 
+    let weft_systems_found:Array<boolean> = input_systems.wesy.map(weft_sys => 
+     original_systems.wesy.find(el => el == weft_sys) !== undefined);
+     if(weft_systems_found.filter(el => el == true).length == 0){
+        formatted_systems.valid = false;
+        return formatted_systems;
+     }else{
+        formatted_systems.wesy = input_systems.wesy;
+     }
+  }else{
+     formatted_systems.wesy = original_systems.wesy.slice();
+  }
+  
+  if(input_systems.wasy.length != 0){
+  //at least one weft systems needs to be valid; 
+    let warp_systems_found:Array<boolean> = input_systems.wasy.map(warp_sys => 
+     original_systems.wasy.find(el => el == warp_sys) !== undefined);
+     if(warp_systems_found.filter(el => el == true).length == 0){
+        formatted_systems.valid = false;
+        return formatted_systems;
+     }else{
+        formatted_systems.wasy = input_systems.wasy;
+     }
+  }else{
+     formatted_systems.wasy = original_systems.wasy.slice();
+  }
+  
+  return formatted_systems;
+  
+
+
+}
+
 async saveAsBmp(el: any, draft: Draft, selected_origin_option:number, ms :MaterialsService, fs: FileService){
     let context = el.getContext('2d');
 
@@ -1315,6 +1363,8 @@ async saveAsBmp(el: any, draft: Draft, selected_origin_option:number, ms :Materi
     });
   
   }
+
+  
 
 }
   

--- a/src/app/core/operations/analyzesystem/analyzesystem.ts
+++ b/src/app/core/operations/analyzesystem/analyzesystem.ts
@@ -1,0 +1,158 @@
+import { getCellValue } from "../../model/cell";
+import { Draft, Operation, OperationInlet, OpInput, OpParamVal, StringParam } from "../../model/datatypes";
+import { generateMappingFromPattern, initDraftFromDrawdown, initDraftWithParams, warps, wefts } from "../../model/drafts";
+import { getAllDraftsAtInlet, getOpParamValById, parseDraftNames } from "../../model/operations";
+import { Sequence } from "../../model/sequence";
+import utilInstance from "../../model/util";
+
+const name = "analyzesystem";
+const old_names = [];
+
+//PARAMS
+
+const pattern:StringParam =  
+    {name: 'systems',
+    type: 'string',
+    value: 'a1',
+    regex: /[\S]/i, //Accepts a letter followed by a number, a single letter or a single number
+    error: 'invalid entry',
+    dx: 'enter the letter or number associated with the weft/warp system to which this draft will be focused upon. For example, "a 1" will show only the cells associated with the combination of warp system 1 with weft system a. The entry "a b" will create a draft of only the cells assigned to a and b across all warp systems'
+  }
+
+
+
+const params = [pattern];
+
+//INLETS
+const systems: OperationInlet = {
+  name: 'systems draft', 
+  type: 'static',
+  value: null,
+  uses: "warp-and-weft-data",
+  dx: 'the draft that describes the system ordering to use when analyzing the draft',
+  num_drafts: 1
+}
+
+  const draft_inlet: OperationInlet = {
+    name: 'draft',
+    type: 'static',
+    value: null,
+    uses: 'draft',
+    dx: "the draft that will be assigned to a given system",
+    num_drafts: 1
+  }
+
+
+  const inlets = [systems, draft_inlet];
+
+
+const  perform = (op_params: Array<OpParamVal>, op_inputs: Array<OpInput>) : Promise<Array<Draft>> => {
+
+
+  const original_string = getOpParamValById(0, op_params);
+  const original_string_split = utilInstance.parseRegex(original_string, pattern.regex);
+
+  if(op_inputs.length == 0) return Promise.resolve([]);
+
+  const system_map = getAllDraftsAtInlet(op_inputs, 0);
+  if(system_map.length == 0) return Promise.resolve([]); ;
+
+  const draft = getAllDraftsAtInlet(op_inputs, 1);
+  if(draft.length == 0) return Promise.resolve([]); ;
+
+
+  const draft_with_systems = initDraftWithParams(
+    {drawdown: draft[0].drawdown, 
+    rowSystemMapping: system_map[0].rowSystemMapping, 
+    rowShuttleMapping: system_map[0].rowShuttleMapping,
+    colSystemMapping: system_map[0].colSystemMapping, 
+    colShuttleMapping: system_map[0].colShuttleMapping
+  })
+
+
+  let systems = original_string_split.reduce((acc, val) => {
+    return {
+      wesy: acc.wesy.concat(parseWeftSystem(val)), 
+      wasy: acc.wasy.concat(parseWarpSystem(val)),
+    }
+  }, {wesy: [], wasy: []});
+
+  if(systems.wesy.length == 0){
+    systems.wesy = utilInstance.filterToUniqueValues(system_map[0].colSystemMapping)
+  }
+  if(systems.wasy.length == 0){
+    systems.wasy = utilInstance.filterToUniqueValues(system_map[0].rowSystemMapping)
+  }
+
+  let analyzed_draft = new Sequence.TwoD();
+  let rowSysMap = [];
+  let rowShutMap = [];
+  let colSysMap = [];
+  let colShutMap = [];
+  for(let i = 0; i < wefts(draft_with_systems.drawdown); i++){
+    const weftsys = draft_with_systems.rowSystemMapping[i];
+    if(systems.wesy.find(el => el == weftsys) !== undefined){
+      colSysMap = [];
+      colShutMap = [];
+      let row = new Sequence.OneD();
+      rowSysMap.push(weftsys);
+      rowShutMap.push(draft_with_systems.rowShuttleMapping[i]);
+      for(let j = 0; j < warps(draft_with_systems.drawdown); j++){
+        const warpsys = draft_with_systems.colSystemMapping[j];
+        if(systems.wasy.find(el => el == warpsys) !== undefined){
+          colSysMap.push(warpsys);
+          colShutMap.push(draft_with_systems.colShuttleMapping[j]);
+           row.push(getCellValue(draft_with_systems.drawdown[i][j])) 
+        }
+      }
+      analyzed_draft.pushWeftSequence(row.val());
+    }
+  }
+
+
+
+  let d: Draft = initDraftFromDrawdown(analyzed_draft.export());
+  d.rowShuttleMapping = rowShutMap;
+  d.rowSystemMapping = rowSysMap;
+  d.colShuttleMapping = colShutMap;
+  d.colSystemMapping = colSysMap;
+
+  return Promise.resolve([d]);
+};   
+
+
+const generateName = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) : string => {
+
+    let drafts = getAllDraftsAtInlet(op_inputs, 0);
+    let name_list = parseDraftNames(drafts);
+  return "analyze systems("+name_list+")";
+}
+
+
+
+
+//pull out all the nubmers from a notation element into warp systems
+const parseWarpSystem = (val: string) : Array<number> => {
+  let matches = val.match(/\d+/g);
+  if(matches == null || matches.length == 0){
+    console.error("in Layer Notation, no warp system")
+    return [];
+  }
+  return  matches.map(el => parseInt(el)-1);
+
+}
+
+//pull out all the letters from a notation element into weft systems
+const parseWeftSystem = (val: string) : Array<number> => {
+  let matches = val.match(/[a-zA-Z]+/g);
+  if(matches == null || matches.length == 0){
+    console.error("in Layer Notation, no weft system")
+    return [];
+  }
+  return matches.map(match => match.charCodeAt(0) - 97);
+
+}
+  
+
+export const analyzesystem: Operation = {name, old_names, params, inlets, perform, generateName};
+

--- a/src/app/core/operations/combinatorics/combinatorics.ts
+++ b/src/app/core/operations/combinatorics/combinatorics.ts
@@ -38,7 +38,6 @@ const  perform = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) => {
 
       const size: number = getOpParamValById(0, param_vals);
       let selection: number = getOpParamValById(1, param_vals);
-      const download: number = getOpParamValById(2, param_vals);
 
       //adjust by one to convert user input to the array index of the structure
       selection -= 1;

--- a/src/app/core/operations/satin/satin.ts
+++ b/src/app/core/operations/satin/satin.ts
@@ -30,8 +30,8 @@ const shift: NumParam =
 const facing: BoolParam = 
     {name: 'facing',
     type: 'boolean',
-    falsestate: "weft facing",
-    truestate: "warp facing",
+    falsestate: "A",
+    truestate: "B",
     value: 0,
     dx: ''
     }
@@ -76,9 +76,7 @@ const  perform = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) => {
 const generateName = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) : string => {
     const repeat: number = getOpParamValById(0, param_vals);
     const shift: number = getOpParamValById(1, param_vals);
-    const facing: number = getOpParamValById(2, param_vals);
-    const dir: string = (facing) ? "Warp Faced" : "Weft Faced";
-  return repeat+"/"+shift+dir+' Satin';
+    return repeat+"/"+shift+' Satin';
 }
 
 

--- a/src/app/core/operations/selector/selector.ts
+++ b/src/app/core/operations/selector/selector.ts
@@ -1,0 +1,70 @@
+import { NumParam, Operation, OperationInlet, OpInput, OpParamVal } from "../../model/datatypes";
+import { copyDraft, initDraftFromDrawdown, initDraftWithParams } from "../../model/drafts";
+import { getAllDraftsAtInlet, getOpParamValById } from "../../model/operations";
+
+
+const name = "selector";
+const old_names = [];
+
+
+//PARAMS
+const selection:NumParam =  
+    {name: 'selected input',
+    type: 'number',
+    min: 1,
+    max: 10000,
+    value: 1,
+    dx: "which of the active inputs is selected at this time"
+};
+
+
+
+const params = [selection];
+
+
+
+
+const draft_inlet: OperationInlet = {
+    name: 'draft', 
+    type: 'static',
+    value: null,
+    uses: "draft",
+    dx: 'a collection of drafts you can switch between',
+    num_drafts: -1
+  }
+
+const inlets = [draft_inlet];
+
+const  perform = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) => {
+
+      const selection: number = getOpParamValById(0, param_vals);
+      const inputs = getAllDraftsAtInlet(op_inputs, 0);
+
+
+      if((selection-1) < inputs.length){
+        let copy = copyDraft(inputs[selection-1]);
+        return Promise.resolve([copy])
+      }else{
+        let draft = initDraftWithParams({wefts: 1, warps:1})
+        return Promise.resolve([draft]);
+      }
+  }   
+
+
+const generateName = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) : string => {
+  const selection: number = getOpParamValById(0, param_vals);
+  const inputs = getAllDraftsAtInlet(op_inputs, 0);
+
+  
+    if((selection-1) < inputs.length){
+      return 'selected:'+inputs[selection-1].ud_name;
+    }else{
+      return 'selected: none';
+    }
+}
+
+
+export const selector: Operation = {name, old_names, params, inlets, perform, generateName};
+
+
+

--- a/src/app/core/operations/selector/selector.ts
+++ b/src/app/core/operations/selector/selector.ts
@@ -1,5 +1,5 @@
 import { NumParam, Operation, OperationInlet, OpInput, OpParamVal } from "../../model/datatypes";
-import { copyDraft, initDraftFromDrawdown, initDraftWithParams } from "../../model/drafts";
+import { copyDraft, getDraftName, initDraftFromDrawdown, initDraftWithParams } from "../../model/drafts";
 import { getAllDraftsAtInlet, getOpParamValById } from "../../model/operations";
 
 
@@ -53,11 +53,10 @@ const  perform = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) => {
 
 const generateName = (param_vals: Array<OpParamVal>, op_inputs: Array<OpInput>) : string => {
   const selection: number = getOpParamValById(0, param_vals);
-  const inputs = getAllDraftsAtInlet(op_inputs, 0);
 
-  
-    if((selection-1) < inputs.length){
-      return 'selected:'+inputs[selection-1].ud_name;
+    if((selection-1) < op_inputs.length){
+      let name = getDraftName(op_inputs[selection-1].drafts[0])
+      return 'selected:'+name;
     }else{
       return 'selected: none';
     }

--- a/src/app/core/operations/twill/twill.ts
+++ b/src/app/core/operations/twill/twill.ts
@@ -41,8 +41,8 @@ const sz: BoolParam =
 const facing: BoolParam = 
     {name: 'facing',
     type: 'boolean',
-    falsestate: "weft facing",
-    truestate: "warp facing",
+    falsestate: "A",
+    truestate: "B",
     value: 0,
     dx: ''
     }

--- a/src/app/core/provider/file.service.ts
+++ b/src/app/core/provider/file.service.ts
@@ -113,17 +113,27 @@ export class FileService {
       if(utilInstance.sameOrNewerVersion(version, '3.4.5')){
     
         draft_nodes = data.draft_nodes;
+
         if(draft_nodes == undefined) draft_nodes = [];
 
         if(draft_nodes !== undefined){
 
-          draft_nodes.forEach(el => {
+
+
+          draft_nodes.forEach((el, ndx) => {
 
             if(el.draft_id !== el.node_id){
               el.draft_id = el.node_id;
               if(el.draft !== null && el.draft !== undefined) el.draft.id = el.node_id;
 
               if(el.compressed_draft !== null && el.compressed_draft !== undefined) el.compressed_draft.id = el.node_id;
+
+              if(data.draft_nodes[ndx].draft_name !== undefined){
+                el.ud_name = '';
+                el.gen_name = data.draft_nodes[ndx].draft_name;
+              }
+
+
             }
 
             if(el.draft == undefined && el.compressed_draft !== undefined && el.compressed_draft !== null){
@@ -162,7 +172,8 @@ export class FileService {
           const dn: DraftNodeProxy = {
             node_id: (node === undefined) ? -1 : node.node_id,
             draft_id: node.node_id,
-            draft_name: node.draft_name,
+            ud_name: (node.draft_name) ? node.draft_name : node.ud_name,
+            gen_name: (node.draft_name) ? node.draft_name : node.gen_name,
             draft: null,
             compressed_draft: null,
             draft_visible: (node === undefined) ? true : node.draft_visible,

--- a/src/app/core/provider/operation.service.ts
+++ b/src/app/core/provider/operation.service.ts
@@ -73,6 +73,7 @@ import { glitchsatin } from '../operations/glitchsatin/glitchsatin';
 import { apply_warp_mats } from '../operations/applywarpmaterials/applywarpmaterials';
 import { apply_weft_mats } from '../operations/applyweftmaterials/applyweftmaterials';
 import {selector} from '../operations/selector/selector'
+import { analyzesystem } from '../operations/analyzesystem/analyzesystem';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/provider/operation.service.ts
+++ b/src/app/core/provider/operation.service.ts
@@ -73,6 +73,7 @@ import {flip} from '../operations/flip/flip'
 import { glitchsatin } from '../operations/glitchsatin/glitchsatin';
 import { apply_warp_mats } from '../operations/applywarpmaterials/applywarpmaterials';
 import { apply_weft_mats } from '../operations/applyweftmaterials/applyweftmaterials';
+import { analyzesystem } from '../operations/analyzesystem/analyzesystem';
 
 @Injectable({
   providedIn: 'root'
@@ -153,6 +154,7 @@ export class OperationService {
     this.ops.push(shift);
     this.ops.push(flip);
     this.ops.push(overlay_multi);
+    this.ops.push(analyzesystem);
 
   //   //this.ops.push(germanify);
   //   //this.ops.push(crackleify);

--- a/src/app/core/provider/operation.service.ts
+++ b/src/app/core/provider/operation.service.ts
@@ -73,6 +73,7 @@ import {flip} from '../operations/flip/flip'
 import { glitchsatin } from '../operations/glitchsatin/glitchsatin';
 import { apply_warp_mats } from '../operations/applywarpmaterials/applywarpmaterials';
 import { apply_weft_mats } from '../operations/applyweftmaterials/applyweftmaterials';
+import {selector} from '../operations/selector/selector'
 
 @Injectable({
   providedIn: 'root'
@@ -172,6 +173,7 @@ export class OperationService {
     this.ops.push(sawtooth);
     this.ops.push(glitchsatin)
     // this.ops.push(hydra)
+    this.ops.push(selector)
     }
 
 

--- a/src/app/core/provider/tree.service.ts
+++ b/src/app/core/provider/tree.service.ts
@@ -1346,14 +1346,12 @@ clearDraft(dn: DraftNode){
    */
   performGenerationOps(op_node_list: Array<number>) : Promise<any> {
 
-
     const needs_computing = op_node_list.filter(el => this.getOpNode(el).dirty);
 
     if(needs_computing.length == 0) return Promise.resolve([]);
 
     const op_fn_list = needs_computing.map(el => this.performOp(el));
    
-    
     return Promise.all(op_fn_list).then( out => {
 
       return this.getNodesWithDependenciesSatisfied();
@@ -1388,7 +1386,6 @@ isValidIOTuple(io: IOTuple) : boolean {
  * @param op_id the operation triggering this series of update
  */
  async performOp(id:number) : Promise<Array<number>> {
-
 
   const opnode = <OpNode> this.getNode(id);
   const op = this.ops.getOp(opnode.name);

--- a/src/app/core/provider/tree.service.ts
+++ b/src/app/core/provider/tree.service.ts
@@ -1226,6 +1226,13 @@ clearDraft(dn: DraftNode){
   const update_looms = [];
   const new_draft_fns = [];
 
+  const param_vals = op.params.map((param, ndx) => {
+    return {
+      param: param,
+      val: opnode.params[ndx]
+    }
+  })
+
   //first, cycle through the resulting nodes: 
   for(let i = 0; i < res.length; i++){
 
@@ -1235,9 +1242,11 @@ clearDraft(dn: DraftNode){
     if(active_tn_tuple !== undefined){
       let cxn_child = this.getOutputs(active_tn_tuple.tn.node.id);
       if(cxn_child.length > 0){
+        res[i].gen_name = op.generateName(param_vals, inputs)
         this.setDraftOnly(cxn_child[0], res[i]);
         touched.push(cxn_child[0]);
         update_looms.push({id: cxn_child[0], draft: res[i]});
+        
       }
     }else{
     //this is a new draft
@@ -1253,26 +1262,20 @@ clearDraft(dn: DraftNode){
 
   //now sweep through and see if there are any existing outputs we need to remove
   out.forEach((output, ndx) => {
+
     if(touched.find(el => el == output) === undefined){
       const dn = <DraftNode> this.getNode(output);
       dn.mark_for_deletion = true;
       this.clearDraft(dn);
     }
   });
-  
+
+
 
 
     return Promise.all(new_draft_fns)
     .then(drafts_loaded => {
-
-      //gather the parameters to generate parameter names
-      const param_vals = op.params.map((param, ndx) => {
-        return {
-          param: param,
-          val: opnode.params[ndx]
-        }
-      })
-
+   
      const ids = drafts_loaded.map(el => el.entry.cur_id);
      ids.forEach((id, ndx) => {
       let d = this.getDraft(id);
@@ -1390,13 +1393,10 @@ isValidIOTuple(io: IOTuple) : boolean {
   const op = this.ops.getOp(opnode.name);
   const all_inputs = this.getInputsWithNdx(id);
 
-  // console.log("PERFORMING ", opnode.name)
-
   
   if(op === null || op === undefined) return Promise.reject("Operation is null")
 
   let inputs: Array<OpInput> = [];
-  //if(this.ops.isDynamic(opnode.name)){
     
   const param_vals = op.params.map((param, ndx) => {
     return {
@@ -1407,7 +1407,6 @@ isValidIOTuple(io: IOTuple) : boolean {
 
 
     const draft_id_to_ndx = [];
-    const ops = [];
    
     all_inputs.filter(el => this.isValidIOTuple(el))
     .forEach((el) => {
@@ -1417,21 +1416,14 @@ isValidIOTuple(io: IOTuple) : boolean {
     });
 
 
-
     const paraminputs = draft_id_to_ndx.map(el => {
       return {drafts: [el.draft], inlet_id: el.ndx, params: [opnode.inlets[el.ndx]]}
     })
     const cleaned_inputs: Array<OpInput> = paraminputs.filter(el => el !== undefined);
 
-    // inputs = inputs.concat(cleaned_inputs);
-    
-
-
-    
     
     return op.perform(param_vals, cleaned_inputs)
     .then(res => {
-        // console.log("OP RETURNED ", res)
         opnode.dirty = false;
         return this.updateDraftsFromResults(id, res, inputs);
       })
@@ -2130,7 +2122,8 @@ isValidIOTuple(io: IOTuple) : boolean {
           const savable: DraftNodeProxy = {
           node_id: node.id,
           draft_id: (<DraftNode>node).draft.id,
-          draft_name: getDraftName((<DraftNode>node).draft),
+          ud_name: (<DraftNode>node).draft.ud_name,
+          gen_name: (<DraftNode>node).draft.gen_name,
           draft: null,
           compressed_draft: (this.hasParent(node.id)) ? null : compressDraft((<DraftNode>node).draft),
           draft_visible:  ((<DraftNode>node).visible == undefined ) ? !this.ws.hide_mixer_drafts :  (<DraftNode>node).visible,
@@ -2216,7 +2209,8 @@ isValidIOTuple(io: IOTuple) : boolean {
     const draft_node: DraftNodeProxy = {
       node_id: id,
       draft_id: draft.id,
-      draft_name: '',
+      ud_name: '',
+      gen_name: '',
       draft: null,
       compressed_draft: null,
       draft_visible: true,

--- a/src/app/core/provider/tree.service.ts
+++ b/src/app/core/provider/tree.service.ts
@@ -1226,6 +1226,7 @@ clearDraft(dn: DraftNode){
   const update_looms = [];
   const new_draft_fns = [];
 
+
   const param_vals = op.params.map((param, ndx) => {
     return {
       param: param,
@@ -1425,7 +1426,7 @@ isValidIOTuple(io: IOTuple) : boolean {
     return op.perform(param_vals, cleaned_inputs)
     .then(res => {
         opnode.dirty = false;
-        return this.updateDraftsFromResults(id, res, inputs);
+        return this.updateDraftsFromResults(id, res, cleaned_inputs);
       })
   }
 

--- a/src/app/core/provider/version.service.ts
+++ b/src/app/core/provider/version.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 })
 export class VersionService {
 
-  private version: string = '4.3.2'
+  private version: string = '4.3.3'
 
 
   constructor() { 

--- a/src/app/mixer/mixer.component.ts
+++ b/src/app/mixer/mixer.component.ts
@@ -514,7 +514,8 @@ zoomChange(zoom_index:any){
     let dnproxy: DraftNodeProxy = {
       node_id: id,
       draft_id: id,
-      draft_name: getDraftName(draft),
+      ud_name: draft.ud_name,
+      gen_name: draft.gen_name,
       draft: draft,
       compressed_draft: null,
       draft_visible: !defaults.hide_mixer_drafts,

--- a/src/app/mixer/palette/connection/connection.component.html
+++ b/src/app/mixer/palette/connection/connection.component.html
@@ -13,11 +13,6 @@ aria-label="Example icon button with a menu icon">
 <i class="fas fa-times"></i></button>
 
 
-<svg id="svg-{{id}}"  xmlns="http://www.w3.org/2000/svg">
-
-  </svg>
-
-
 </div>
 
 

--- a/src/app/mixer/palette/connection/connection.component.scss
+++ b/src/app/mixer/palette/connection/connection.component.scss
@@ -17,3 +17,17 @@ button{
     display: none;
 }
 
+.moving-dash {
+stroke: #0077cc;
+stroke-linecap: round;
+stroke-dasharray: 10 10; /* dash length + gap */
+animation: dash-slide 1s linear infinite;
+}
+
+@keyframes dash-slide {
+to {
+    stroke-dashoffset: -20; /* negative makes dashes move forward */
+}
+}
+
+

--- a/src/app/mixer/palette/connection/connection.component.scss
+++ b/src/app/mixer/palette/connection/connection.component.scss
@@ -2,7 +2,7 @@
 
 .connection-container{
     position: absolute;
-    z-index: 20;
+    z-index: 0;
     //pointer-events:none;
 }
 
@@ -18,7 +18,7 @@ button{
 }
 
 .moving-dash {
-stroke: #0077cc;
+stroke: #bbbdbf;
 stroke-linecap: round;
 stroke-dasharray: 10 10; /* dash length + gap */
 animation: dash-slide 1s linear infinite;

--- a/src/app/mixer/palette/connection/connection.component.ts
+++ b/src/app/mixer/palette/connection/connection.component.ts
@@ -94,6 +94,22 @@ export class ConnectionComponent implements OnInit {
       }
     );
     this.anim.pause();
+    const color = "#000000"
+    const stroke_width = 2;
+     this.path_main.setAttribute("fill", "none");
+    this.path_main.setAttribute("stroke", color);
+    this.path_main.setAttribute("stroke-width", "4"); //2
+    this.path_main.setAttribute("stroke-linecap", "round");
+    this.path_main.setAttribute("stroke-dasharray", "10 10"); //4 2 
+    this.path_main.setAttribute("stroke-dashoffset", "0");
+ 
+    this.line_stub.setAttribute("fill", "none");
+    this.line_stub.setAttribute("stroke", color);
+    this.line_stub.setAttribute("stroke-width", "4"); //2
+    this.line_stub.setAttribute("stroke-linecap", "round");
+    this.line_stub.setAttribute("stroke-dasharray", "10 10"); //4 2 
+    this.line_stub.setAttribute("stroke-dashoffset", "0"); 
+
 
 
     let to_withdata = this.tree.getConnectionOutputWithIndex(this.id);
@@ -257,13 +273,14 @@ export class ConnectionComponent implements OnInit {
 
     if(selected){
     // this.anim.play();
-     this.path_main.setAttribute("stroke-width", "16"); //2
-     this.line_stub.setAttribute("stroke-width", "16"); //2
-    this.path_main.setAttribute("stroke-dasharray", "40 40"); //4 2 
-    this.line_stub.setAttribute("stroke-dasharray", "40 40"); //4 2 
+     this.path_main.setAttribute("stroke-width", "8"); //2
+     this.line_stub.setAttribute("stroke-width", "8"); //2
+    this.path_main.setAttribute("stroke-dasharray", "20 1"); //4 2 
+    this.line_stub.setAttribute("stroke-dasharray", "20 1"); //4 2 
 
     }else{
    //  this.anim.pause();
+    this.path_main.style.zIndex = '0'
      this.path_main.setAttribute("stroke-width", "4"); //2
      this.line_stub.setAttribute("stroke-width", "4"); //2
      this.path_main.setAttribute("stroke-dasharray", "10 10"); //4 2 
@@ -289,26 +306,6 @@ export class ConnectionComponent implements OnInit {
     const connector_font_size = 2;
     const button_margin_left = -24;
     const button_margin_top = -8;
-    const color = "#000000"
-    const stroke_width = 2;
-
-    this.path_main.setAttribute("fill", "none");
-    this.path_main.setAttribute("stroke", color);
-    this.path_main.setAttribute("stroke-width", "4"); //2
-    this.path_main.setAttribute("stroke-linecap", "round");
-    this.path_main.setAttribute("stroke-dasharray", "10 10"); //4 2 
-    this.path_main.setAttribute("stroke-dashoffset", "0");
- 
-    this.line_stub.setAttribute("fill", "none");
-    this.line_stub.setAttribute("stroke", color);
-    this.line_stub.setAttribute("stroke-width", "4"); //2
-    this.line_stub.setAttribute("stroke-linecap", "round");
-    this.line_stub.setAttribute("stroke-dasharray", "10 10"); //4 2 
-    this.line_stub.setAttribute("stroke-dashoffset", "0"); 
-
-
-     
-
 
     if(this.orientation_x && this.orientation_y){
       

--- a/src/app/mixer/palette/connection/connection.component.ts
+++ b/src/app/mixer/palette/connection/connection.component.ts
@@ -31,8 +31,11 @@ export class ConnectionComponent implements OnInit {
   width: number =  0;
   height: number = 0;
 
-  svg: HTMLElement;
+  svg: SVGSVGElement;
+  path_main: SVGPathElement;
+  line_stub: SVGLineElement;
   connector: HTMLElement;
+  anim: any;
 
   no_draw: boolean;
 
@@ -66,8 +69,31 @@ export class ConnectionComponent implements OnInit {
 
   ngAfterViewInit(){
 
-    this.svg = document.getElementById('svg-'+this.id.toString());
+
+    const ns = "http://www.w3.org/2000/svg";
+    this.svg = document.createElementNS(ns, "svg");
+    this.path_main = document.createElementNS(ns, "path");
+    this.line_stub = document.createElementNS(ns, "line");
+    this.svg.appendChild(this.path_main);
+    this.svg.appendChild(this.line_stub);
+    document.getElementById("scale-"+this.id).appendChild(this.svg);
+
+
+    //this.svg = document.getElementById('svg-'+this.id.toString());
     this.connector = document.getElementById('connector-'+this.id.toString());
+
+    this.anim = this.path_main.animate(
+      [
+        { strokeDashoffset: "0" },
+        { strokeDashoffset: "20" }
+      ],
+      {
+        duration: 1000,
+        iterations: Infinity,
+        easing: "linear"
+      }
+    );
+    this.anim.pause();
 
 
     let to_withdata = this.tree.getConnectionOutputWithIndex(this.id);
@@ -77,8 +103,7 @@ export class ConnectionComponent implements OnInit {
 
      this.updateFromPosition();
      this.updateToPosition(to_withdata.inlet, to_withdata.arr);
-
-     this.drawConnection()
+     this.drawConnection();
 
 
   }
@@ -228,98 +253,135 @@ export class ConnectionComponent implements OnInit {
   }
 
 
+  updateConnectionStyling(selected: boolean){
+
+    if(selected){
+    // this.anim.play();
+     this.path_main.setAttribute("stroke-width", "16"); //2
+     this.line_stub.setAttribute("stroke-width", "16"); //2
+    this.path_main.setAttribute("stroke-dasharray", "40 40"); //4 2 
+    this.line_stub.setAttribute("stroke-dasharray", "40 40"); //4 2 
+
+    }else{
+   //  this.anim.pause();
+     this.path_main.setAttribute("stroke-width", "4"); //2
+     this.line_stub.setAttribute("stroke-width", "4"); //2
+     this.path_main.setAttribute("stroke-dasharray", "10 10"); //4 2 
+     this.line_stub.setAttribute("stroke-dasharray", "10 10"); //4 2 
+
+
+
+    }  
+  }
+
+  
+
 
   
   drawConnection(){
 
-
-    const stublength = 40;
-    const connector_opening = 20;
-    // const connector_font_size = Math.max((10 - scale) / 10, .75);
-    const connector_font_size = 2;
-    const text_path_font_size =   Math.max((10 - this.zs.getMixerZoom()) / 10, .75);
-    const button_margin_left = -24;
-    const button_margin_top = -16;
-    const color = "#000000"
-    
     if(this.no_draw) return;
     if(this.svg === null || this.svg == undefined) return;
 
+
+    const stublength = 40;
+    const connector_opening = 40;
+    const connector_font_size = 2;
+    const button_margin_left = -24;
+    const button_margin_top = -8;
+    const color = "#000000"
     const stroke_width = 2;
+
+    this.path_main.setAttribute("fill", "none");
+    this.path_main.setAttribute("stroke", color);
+    this.path_main.setAttribute("stroke-width", "4"); //2
+    this.path_main.setAttribute("stroke-linecap", "round");
+    this.path_main.setAttribute("stroke-dasharray", "10 10"); //4 2 
+    this.path_main.setAttribute("stroke-dashoffset", "0");
+ 
+    this.line_stub.setAttribute("fill", "none");
+    this.line_stub.setAttribute("stroke", color);
+    this.line_stub.setAttribute("stroke-width", "4"); //2
+    this.line_stub.setAttribute("stroke-linecap", "round");
+    this.line_stub.setAttribute("stroke-dasharray", "10 10"); //4 2 
+    this.line_stub.setAttribute("stroke-dashoffset", "0"); 
+
+
+     
 
 
     if(this.orientation_x && this.orientation_y){
       
-      this.svg.innerHTML = ' <path id="path-'+this.id+'" d="M 0 0 C 0 50, '+this.width+' '+(this.height-70)+', '+this.width+' '+(this.height-(stublength+connector_opening))+'" fill="transparent" stroke="'+color+'"  stroke-dasharray="4 2"  stroke-width="'+stroke_width+'"/>' ;
+      this.path_main.setAttribute("d", "M 0 0 C 0 50, "+this.width+" "+(this.height-70)+","+this.width+" "+(this.height-(stublength+connector_opening)));
 
-      if(this.show_path_text){
-        this.svg.innerHTML += '<text><textPath startOffset="10%" fill="'+color+'" href="#path-'+this.id+'">'+this.path_text+'</textPath></text> ';
+      this.line_stub.setAttribute("x1", this.width+"");
+      this.line_stub.setAttribute("y1", (this.height-(stublength))+"");
+      this.line_stub.setAttribute("x2", this.width+"");
+      this.line_stub.setAttribute("y2", this.height+"");
 
-      }
-     
-
-      this.svg.innerHTML += '  <line x1="'+this.width+'" y1="'+(this.height-(stublength))+'" x2='+this.width+' y2="'+this.height+'"  stroke="'+color+'"  stroke-dasharray="4 2"   stroke-width="'+stroke_width+'" />';
 
       this.connector.style.top = (this.height-(stublength+connector_opening)+button_margin_top)+'px';
       this.connector.style.left = (this.width+button_margin_left)+'px';
       this.connector.style.fontSize = connector_font_size+"em";
-      this.svg.style.fontSize = text_path_font_size+"em";
       
-  
+
 
     }else if(!this.orientation_x && !this.orientation_y){
-      this.svg.innerHTML = ' <path id="path-'+this.id+'" d="M 0 '+-(stublength+connector_opening)+' c 0 -50, '+this.width+' '+(this.height+100)+', '+this.width+' '+(this.height+(stublength+connector_opening))+'" fill="transparent" stroke="'+color+'"  stroke-dasharray="4 2"   stroke-width="'+stroke_width+'"/> ' ;
 
-      if(this.show_path_text){
-        this.svg.innerHTML += ' <text><textPath startOffset="60%" fill="'+color+'" href="#path-'+this.id+'">'+this.path_text+'</textPath></text>';
-      }
+      this.path_main.setAttribute("d", "M 0 "+-(stublength+connector_opening)+"c 0 -50, "+this.width+" "+(this.height+100)+", "+this.width+" "+(this.height+(stublength+connector_opening)));
 
-      this.svg.innerHTML += '  <line x1="0" y1="'+-(stublength )+'" x2="0" y2="0"  stroke="'+color+'"  stroke-dasharray="4 2"   stroke-width="'+stroke_width+'" />';
+
+      this.line_stub.setAttribute("x1","0");
+      this.line_stub.setAttribute("y1", -(stublength)+"");
+      this.line_stub.setAttribute("x2", "0");
+      this.line_stub.setAttribute("y2", "0");
 
       this.connector.style.top = -(stublength+connector_opening)+(button_margin_top)+'px';
       this.connector.style.left = (button_margin_left)+'px';
       this.connector.style.fontSize = connector_font_size+"em";
-      this.svg.style.fontSize = text_path_font_size+"em";
   
 
 
     }else if(!this.orientation_x && this.orientation_y){
 
-      // this.svg.innerHTML = ' <path id="path-'+this.id+'" d="M '+this.bounds.width+' 0 C '+(this.bounds.width)+' 50, 0 '+(this.bounds.height-70)+', 0 '+(this.bounds.height-(stublength+connector_opening))+'" fill="transparent" stroke="#ff4081"  stroke-dasharray="4 2"   stroke-width="'+stroke_width+'"/> <text><textPath startOffset="50%" fill="#000000" href="#path-'+this.id+'">'+this.path_text+'</textPath></text> ' ;
+
+      this.path_main.setAttribute("d", "M  0 "+(this.height-(stublength+connector_opening))+" C 0 "+(this.height-(stublength+connector_opening)-50)+", "+this.width+" 50, "+this.width+" 0");
+
+      this.line_stub.setAttribute("x1","0");
+      this.line_stub.setAttribute("y1",(this.height-(stublength))+"");
+      this.line_stub.setAttribute("x2", "0");
+      this.line_stub.setAttribute("y2", this.height+"");
 
 
-      this.svg.innerHTML = ' <path id="path-'+this.id+'" d=" M  0 '+(this.height-(stublength+connector_opening))+' C 0 '+(this.height-(stublength+connector_opening)-50)+', '+this.width+' 50, '+this.width+' 0" fill="transparent" stroke="'+color+'"  stroke-dasharray="4 2"   stroke-width="'+stroke_width+'"/> ' ;
-
-      if(this.show_path_text){
-        this.svg.innerHTML += '<text><textPath startOffset="60%" fill="'+color+'" href="#path-'+this.id+'">'+this.path_text+'</textPath></text>';
-      }
-
-      this.svg.innerHTML += '  <line x1="0" y1="'+(this.height-(stublength))+'" x2="0" y2="'+this.height+'"  stroke="'+color+'"  stroke-dasharray="4 2"   stroke-width="'+stroke_width+'" />';
 
 
       this.connector.style.top = (this.height-(stublength+connector_opening)+button_margin_top)+'px';
       this.connector.style.left =  (button_margin_left)+'px';
       this.connector.style.fontSize = connector_font_size+"em";
-      this.svg.style.fontSize = text_path_font_size+"em";
   
   
 
 
     }else{
 
-      this.svg.innerHTML = ' <path id="path-'+this.id+'" d="M 0 '+this.height+' C 0 '+(this.height+50)+', '+this.width+' -50, '+this.width+''+-(stublength+connector_opening)+'" fill="transparent" stroke="'+color+'"  stroke-dasharray="4 2"  stroke-width="'+stroke_width+'"/>' ;
+      
 
-      if(this.show_path_text){
-        this.svg.innerHTML = '<text><textPath startOffset="10%" fill="'+color+'" href="#path-'+this.id+'">'+this.path_text+'</textPath></text> ';
-      }
+      this.path_main.setAttribute("d", "M 0 "+this.height+"C 0 "+(this.height+50)+", "+this.width+" -50, "+this.width+" "+-(stublength+connector_opening));
 
-      this.svg.innerHTML += '  <line x1="'+this.width+'" y1="'+(-(stublength))+'" x2="'+this.width+'" y2="0"  stroke="'+color+'"  stroke-dasharray="4 2"   stroke-width="'+stroke_width+'" />';
+
+      // this.svg.innerHTML = ' <path id="path-'+this.id+'" d="M 0 '+this.height+' C 0 '+(this.height+50)+', '+this.width+' -50, '+this.width+''+-(stublength+connector_opening)+'" fill="transparent" stroke="'+color+'"  stroke-dasharray="4 2"  stroke-width="'+stroke_width+'"/>' ;
+
+
+      this.line_stub.setAttribute("x1",this.width+"");
+      this.line_stub.setAttribute("y1",-(stublength)+"");
+      this.line_stub.setAttribute("x2", this.width+"");
+      this.line_stub.setAttribute("y2", "0");
+
 
 
       this.connector.style.top = -(stublength+connector_opening)+(button_margin_top)+'px';
       this.connector.style.left = (this.width+button_margin_left)+'px';
       this.connector.style.fontSize = connector_font_size+"em";
-      this.svg.style.fontSize = text_path_font_size+"em";
   
 
     }

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.html
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.html
@@ -132,26 +132,11 @@ source = "mixer"
 <div class="output_meta">
   <div class="draftname">
     
+  {{draft_name}}    
+  <button mat-icon-button aria-label="Example icon button with a vertical three dot icon"  (click)="rename($event)">
+       <i class="fas fa-edit"></i>
+      </button>
 
-  <form class="example-form">
-    <mat-form-field class="example-full-width">
-      <mat-label>Draft Name</mat-label>
-      <input matInput placeholder="Ex. Pizza" value="Sushi">
-    </mat-form-field>
-        <mat-form-field>
-      <mat-label>Ends</mat-label>
-      <input matInput value="{{warps}}">
-    </mat-form-field>
-        <mat-form-field disabled>
-      <mat-label>Pics</mat-label>
-      <input matInput value="{{wefts}}">
-    </mat-form-field>
-    </form>
-    <!-- <button 
-    mat-flat-button
-    (click)="rename($event)">
-      {{draft_name}}    
-  </button> -->
   </div>
 
   <div class="dims">{{warps}} x {{wefts}}</div>

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.html
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.html
@@ -130,7 +130,29 @@ source = "mixer"
 
 
 <div class="output_meta">
-  <div class="draftname">{{draft_name}}</div>
+  <div class="draftname">
+    
+
+  <form class="example-form">
+    <mat-form-field class="example-full-width">
+      <mat-label>Draft Name</mat-label>
+      <input matInput placeholder="Ex. Pizza" value="Sushi">
+    </mat-form-field>
+        <mat-form-field>
+      <mat-label>Ends</mat-label>
+      <input matInput value="{{warps}}">
+    </mat-form-field>
+        <mat-form-field disabled>
+      <mat-label>Pics</mat-label>
+      <input matInput value="{{wefts}}">
+    </mat-form-field>
+    </form>
+    <!-- <button 
+    mat-flat-button
+    (click)="rename($event)">
+      {{draft_name}}    
+  </button> -->
+  </div>
 
   <div class="dims">{{warps}} x {{wefts}}</div>
  

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.html
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.html
@@ -130,16 +130,20 @@ source = "mixer"
 
 
 <div class="output_meta">
-  <div class="draftname">
-    
-  {{draft_name}}    
-  <button mat-icon-button aria-label="Example icon button with a vertical three dot icon"  (click)="rename($event)">
+ 
+  <div class="name_and_dims">
+    <div class="text">
+      <div class="name">{{draft_name}} </div>  
+      <div class="dims">{{warps}} x {{wefts}}</div>
+    </div>
+    <div class="edit_button">
+      <button mat-icon-button (click)="rename($event)">
        <i class="fas fa-edit"></i>
       </button>
-
+    </div>
+ 
   </div>
 
-  <div class="dims">{{warps}} x {{wefts}}</div>
  
 
   <canvas #bitmapImage hidden></canvas>
@@ -156,7 +160,6 @@ source = "mixer"
     matTooltip = "connect this draft to an operation"
     (click)="connectionStarted($event)">
       <i class="fa-sharp fa-solid fa-circle-down"></i>  
-      <!-- {{id}} -->
     </button>
 </div>
 

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.scss
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.scss
@@ -24,6 +24,21 @@ button.output{
     width: 100%;
 }
 
+
+
+.name_and_dims{
+	height: 60px;
+	display: flex;
+	flex-direction: row;
+}
+
+.text{
+	margin: 6px 0px;
+
+}
+
+
+
 .show_draft{
 	margin: 0px 16px;
     color: black;

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
@@ -166,7 +166,7 @@ export class DraftContainerComponent implements AfterViewInit{
 
       if(!changes['dirty'].firstChange){
         if(this.draft_rendering !== undefined && draft !== undefined && draft !== null){
-          console.log("UPDATING ", getDraftName(draft))
+
           this.draft_name = getDraftName(draft);
           this.draft_rendering.onNewDraftLoaded(this.id);
           this.drawDraft(draft);
@@ -277,7 +277,7 @@ export class DraftContainerComponent implements AfterViewInit{
 
     return this.draft_rendering.redraw(draft, loom, loom_settings, flags ).then(el => {
       this.tree.setDraftClean(this.id);
-      this.onDrawdownSizeChanged.emit(true);
+      this.onDrawdownSizeChanged.emit(this.id);
       return Promise.resolve(true);
     })
 
@@ -306,7 +306,6 @@ export class DraftContainerComponent implements AfterViewInit{
   async saveAsPrint() {
     let draft = this.tree.getDraft(this.id);
 
-    console.log("CURRENT VIEW ", this.current_view)
     let floats = (this.current_view == 'draft') ? false : true;
     let color = (this.current_view == 'visual') ? true : false;
 

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
@@ -45,8 +45,6 @@ export class DraftContainerComponent implements AfterViewInit{
 
   exceeds_size: boolean = false;
 
-  ud_name: string = '';
-
   warps: number; 
 
   wefts: number;
@@ -93,7 +91,6 @@ export class DraftContainerComponent implements AfterViewInit{
 
 
     const draft = this.tree.getDraft(this.id);
-    this.ud_name = draft.ud_name;
     this.warps = warps(draft.drawdown);
     this.wefts = wefts(draft.drawdown);
 
@@ -114,9 +111,8 @@ export class DraftContainerComponent implements AfterViewInit{
     });
 
   dialogRef.afterClosed().subscribe(obj => {
-    console.log("UDPATE DRAFT NAME TO ", this.tree.getDraftName(this.id))
     this.draft_name = this.tree.getDraftName(this.id);
-    this.onNameChanged.emit();
+    this.onNameChanged.emit(this.id);
  });
   }
 
@@ -156,11 +152,11 @@ export class DraftContainerComponent implements AfterViewInit{
       this.draft_visible = this.tree.getDraftVisible(this.id);
 
       if(draft == undefined || draft == null){
-        this.ud_name = 'this operation did not create a draft, check to make sure it has all the inputs it needs';
+        this.draft_name = 'this operation did not create a draft, check to make sure it has all the inputs it needs';
         this.warps = 0;
         this.wefts = 0;
       }else{
-        this.ud_name = getDraftName(draft);
+        this.draft_name = getDraftName(draft);
         this.warps = warps(draft.drawdown);
         this.wefts = wefts(draft.drawdown);
       }
@@ -170,8 +166,11 @@ export class DraftContainerComponent implements AfterViewInit{
 
       if(!changes['dirty'].firstChange){
         if(this.draft_rendering !== undefined && draft !== undefined && draft !== null){
+          console.log("UPDATING ", getDraftName(draft))
+          this.draft_name = getDraftName(draft);
           this.draft_rendering.onNewDraftLoaded(this.id);
           this.drawDraft(draft);
+          
         } else{
           this.draft_rendering.clear();
         }

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
@@ -12,6 +12,8 @@ import { WorkspaceService } from '../../../core/provider/workspace.service';
 import { DraftRenderingComponent } from '../../../core/ui/draft-rendering/draft-rendering.component';
 import { ViewerService } from '../../../core/provider/viewer.service';
 import { MatMenuTrigger } from '@angular/material/menu';
+import { MatDialog } from '@angular/material/dialog';
+import { RenameComponent } from '../../../core/modal/rename/rename.component';
 
 @Component({
   selector: 'app-draftcontainer',
@@ -30,6 +32,7 @@ export class DraftContainerComponent implements AfterViewInit{
   @Output() onOpenInEditor = new EventEmitter();
   @Output() onRecomputeChildren = new EventEmitter();
   @Output() onDrawdownSizeChanged = new EventEmitter();
+  @Output() onNameChanged = new EventEmitter();
  
   @ViewChild('bitmapImage') bitmap: any;
   @ViewChild('draft_rendering') draft_rendering: 
@@ -65,6 +68,7 @@ export class DraftContainerComponent implements AfterViewInit{
 
 
   constructor(
+    private dialog: MatDialog,
     private dm: DesignmodesService,
     private ms: MaterialsService,
     private fs: FileService,
@@ -106,7 +110,14 @@ export class DraftContainerComponent implements AfterViewInit{
   }
 
   rename(event){
+    const dialogRef = this.dialog.open(RenameComponent, {data: {id: this.id}
+    });
 
+  dialogRef.afterClosed().subscribe(obj => {
+    console.log("UDPATE DRAFT NAME TO ", this.tree.getDraftName(this.id))
+    this.draft_name = this.tree.getDraftName(this.id);
+    this.onNameChanged.emit();
+ });
   }
 
   onDoubleClick(){

--- a/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
+++ b/src/app/mixer/palette/draftcontainer/draftcontainer.component.ts
@@ -105,6 +105,10 @@ export class DraftContainerComponent implements AfterViewInit{
 
   }
 
+  rename(event){
+
+  }
+
   onDoubleClick(){
     this.trigger.openMenu();
   }

--- a/src/app/mixer/palette/operation/operation.component.html
+++ b/src/app/mixer/palette/operation/operation.component.html
@@ -154,6 +154,7 @@ cdkDrag
         (onDuplicateCalled)="designActionChange($event)"
 				(onDeleteCalled)="designActionChange($event)"
         (onDrawdownSizeChanged)="updateOutboundConnections($event)"
+        (onNameChanged)="nameChanged($event)"
         >
         </app-draftcontainer>
       </div>

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -65,6 +65,7 @@ export class OperationComponent implements OnInit {
    @Output() onOpLoaded = new EventEmitter <any> ();
    @Output() onOpenInEditor = new EventEmitter <any> ();
    @Output() onRedrawOutboundConnections= new EventEmitter <any> ();
+   @Output() onNameChanged= new EventEmitter <any> ();
 
    params_visible: boolean = true;
     /**
@@ -456,6 +457,10 @@ export class OperationComponent implements OnInit {
     }
     
     this.onOperationParamChange.emit({id: this.id, prior_inlet_vals: original_inlets});
+  }
+
+  nameChanged(){
+    this.onNameChanged.emit();
   }
 
   drawImagePreview(){

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -449,8 +449,6 @@ export class OperationComponent implements OnInit {
           opnode.params[1] = image_param.data.width;
           opnode.params[2] = image_param.data.height;
          }
-
-
         }
       }
 

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -15,6 +15,7 @@ import { ViewerService } from '../../../core/provider/viewer.service';
 import { DraftContainerComponent } from '../draftcontainer/draftcontainer.component';
 import { CdkDragMove, CdkDragStart } from '@angular/cdk/drag-drop';
 import { MatMenuTrigger } from '@angular/material/menu';
+import { ConnectionComponent } from '../connection/connection.component';
 
 
 
@@ -239,7 +240,36 @@ export class OperationComponent implements OnInit {
     this.params_visible = !this.params_visible;
   }
 
+
+  updateConnectionStyling(){
+
+      //remove the selected class for all connections
+      let cxns = this.tree.getConnections();
+      for(let cxn of cxns){
+        if(cxn !== null){
+          cxn.updateConnectionStyling(false);
+        }
+      }
+
+      let outputs = [];
+      if(this.children.length > 0){
+        let child = this.children[0];
+        outputs = outputs.concat(this.tree.getOutputs(child))
+      }
+
+      //add the class selected to any of the connections going into and out of this node
+      let ios = outputs.concat(this.tree.getInputs(this.id));
+      for(let io of ios){
+        let cxn = <ConnectionComponent> this.tree.getComponent(io);
+        if(cxn !== null) cxn.updateConnectionStyling(true)
+      }
+
+  }
+
+
   toggleSelection(e: any){
+
+      this.updateConnectionStyling();
 
       if(this.children.length > 0){
         let child = this.children[0];
@@ -519,6 +549,7 @@ export class OperationComponent implements OnInit {
 
 
   dragStart($event: CdkDragStart) {
+    this.updateConnectionStyling();
 
 
     this.offset = null;
@@ -538,6 +569,7 @@ export class OperationComponent implements OnInit {
    */
   dragMove($event: CdkDragMove) {
 
+      this.updateConnectionStyling();
 
     //GET THE LOCATION OF THE POINTER RELATIVE TO THE TOP LEFT OF THE NODE
 
@@ -592,6 +624,7 @@ export class OperationComponent implements OnInit {
 
   dragEnd($event: any) {
 
+      this.updateConnectionStyling();
 
 
     this.multiselect.setRelativePosition(this.topleft);

--- a/src/app/mixer/palette/operation/operation.component.ts
+++ b/src/app/mixer/palette/operation/operation.component.ts
@@ -459,8 +459,8 @@ export class OperationComponent implements OnInit {
     this.onOperationParamChange.emit({id: this.id, prior_inlet_vals: original_inlets});
   }
 
-  nameChanged(){
-    this.onNameChanged.emit();
+  nameChanged(id){
+    this.onNameChanged.emit(id);
   }
 
   drawImagePreview(){

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -474,7 +474,7 @@ handlePan(diff: Point){
     this.subdraftSubscriptions.push(sd.onConnectionStarted.subscribe(this.onConnectionStarted.bind(this)));
     this.subdraftSubscriptions.push(sd.onDesignAction.subscribe(this.onSubdraftAction.bind(this)));
     this.subdraftSubscriptions.push(sd.onSubdraftViewChange.subscribe(this.onSubdraftViewChange.bind(this)));
-    this.subdraftSubscriptions.push(sd.onNameChange.subscribe(this.addTimelineState.bind(this)));
+    this.subdraftSubscriptions.push(sd.onNameChange.subscribe(this.onNameChange.bind(this)));
     this.subdraftSubscriptions.push(sd.onOpenInEditor.subscribe(this.openInEditor.bind(this)));
     this.subdraftSubscriptions.push(sd.onRedrawOutboundConnections.subscribe(this.redrawOutboundConnections.bind(this)));
   }
@@ -670,7 +670,7 @@ handlePan(diff: Point){
     this.operationSubscriptions.push(op.onOpLoaded.subscribe(this.opCompLoaded.bind(this)));
     this.operationSubscriptions.push(op.onOpenInEditor.subscribe(this.openInEditor.bind(this)));
     this.operationSubscriptions.push(op.onRedrawOutboundConnections.subscribe(this.redrawOutboundConnections.bind(this)));
-    this.operationSubscriptions.push(op.onNameChanged.subscribe(this.addTimelineState.bind(this)));
+    this.operationSubscriptions.push(op.onNameChanged.subscribe(this.onNameChange.bind(this)));
 
   }
 
@@ -1368,19 +1368,19 @@ handlePan(diff: Point){
       /**
     * this is called when an subdraft updates its show/hide value
     */
-    // onSubdraftNameChange(id: number){
+    onNameChange(id: number){
 
-    //   const outs = this.tree.getNonCxnOutputs(id);
-    //   const to_perform = outs.map(el => this.performAndUpdateDownstream(el));
-    //   return Promise.all(to_perform) 
-    //   .then(el => 
-    //     {
-    //       this.addTimelineState(); 
-    //     })
-    //     .catch(console.error);;
+      const outs = this.tree.getNonCxnOutputs(id);
+      const to_perform = outs.map(el => this.performAndUpdateDownstream(el));
+      return Promise.all(to_perform) 
+      .then(el => 
+        {
+          this.addTimelineState(); 
+        })
+        .catch(console.error);;
 
        
-    // }
+    }
     
 
 

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -1416,17 +1416,18 @@ connectionDragged(mouse: Point){
   this.active_connection.width =  (adj.x - this.active_connection.topleft.x);
   this.active_connection.height =  (adj.y - this.active_connection.topleft.y);
 
+
+  
   const svg = document.getElementById('scratch_svg');
   svg.style.top = (this.active_connection.topleft.y)+"px";
   svg.style.left = (this.active_connection.topleft.x)+"px"
 
- 
   svg.innerHTML = ' <path d="M 0 0 C 0 50,'
   +(this.active_connection.width)+' '
   +(this.active_connection.height-50)+', '
   +(this.active_connection.width)+' '
   +(this.active_connection.height)
-  +'" fill="transparent" stroke="#ff4081"  stroke-dasharray="4 2"  stroke-width="2"/> ' ;
+  +'" fill="transparent" stroke="#ff4081"  stroke-dasharray="20 1"  stroke-width="8"/> ' ;
 
  
 

--- a/src/app/mixer/palette/palette.component.ts
+++ b/src/app/mixer/palette/palette.component.ts
@@ -259,6 +259,7 @@ handlePan(diff: Point){
 
   }
 
+
   /**
    * adds a state to the timeline. This should be called 
    * each time a user performs an action that they should be able to undo/redo
@@ -473,7 +474,7 @@ handlePan(diff: Point){
     this.subdraftSubscriptions.push(sd.onConnectionStarted.subscribe(this.onConnectionStarted.bind(this)));
     this.subdraftSubscriptions.push(sd.onDesignAction.subscribe(this.onSubdraftAction.bind(this)));
     this.subdraftSubscriptions.push(sd.onSubdraftViewChange.subscribe(this.onSubdraftViewChange.bind(this)));
-    this.subdraftSubscriptions.push(sd.onNameChange.subscribe(this.onSubdraftNameChange.bind(this)));
+    this.subdraftSubscriptions.push(sd.onNameChange.subscribe(this.addTimelineState.bind(this)));
     this.subdraftSubscriptions.push(sd.onOpenInEditor.subscribe(this.openInEditor.bind(this)));
     this.subdraftSubscriptions.push(sd.onRedrawOutboundConnections.subscribe(this.redrawOutboundConnections.bind(this)));
   }
@@ -669,6 +670,7 @@ handlePan(diff: Point){
     this.operationSubscriptions.push(op.onOpLoaded.subscribe(this.opCompLoaded.bind(this)));
     this.operationSubscriptions.push(op.onOpenInEditor.subscribe(this.openInEditor.bind(this)));
     this.operationSubscriptions.push(op.onRedrawOutboundConnections.subscribe(this.redrawOutboundConnections.bind(this)));
+    this.operationSubscriptions.push(op.onNameChanged.subscribe(this.addTimelineState.bind(this)));
 
   }
 
@@ -1366,19 +1368,19 @@ handlePan(diff: Point){
       /**
     * this is called when an subdraft updates its show/hide value
     */
-    onSubdraftNameChange(id: number){
+    // onSubdraftNameChange(id: number){
 
-      const outs = this.tree.getNonCxnOutputs(id);
-      const to_perform = outs.map(el => this.performAndUpdateDownstream(el));
-      return Promise.all(to_perform) 
-      .then(el => 
-        {
-          this.addTimelineState(); 
-        })
-        .catch(console.error);;
+    //   const outs = this.tree.getNonCxnOutputs(id);
+    //   const to_perform = outs.map(el => this.performAndUpdateDownstream(el));
+    //   return Promise.all(to_perform) 
+    //   .then(el => 
+    //     {
+    //       this.addTimelineState(); 
+    //     })
+    //     .catch(console.error);;
 
        
-    }
+    // }
     
 
 

--- a/src/app/mixer/palette/subdraft/subdraft.component.html
+++ b/src/app/mixer/palette/subdraft/subdraft.component.html
@@ -33,6 +33,7 @@
 	(onDeleteCalled)="designAction($event)"
 	(onRecomputeChildren)="designAction($event)"
 	(onDrawdownSizeChanged)="updateOutboundConnections()"
+	(onNameChanged)="nameChange()"
 	></app-draftcontainer>
 
 

--- a/src/app/mixer/palette/subdraft/subdraft.component.html
+++ b/src/app/mixer/palette/subdraft/subdraft.component.html
@@ -33,7 +33,7 @@
 	(onDeleteCalled)="designAction($event)"
 	(onRecomputeChildren)="designAction($event)"
 	(onDrawdownSizeChanged)="updateOutboundConnections()"
-	(onNameChanged)="nameChange()"
+	(onNameChanged)="nameChange($event)"
 	></app-draftcontainer>
 
 

--- a/src/app/mixer/palette/subdraft/subdraft.component.ts
+++ b/src/app/mixer/palette/subdraft/subdraft.component.ts
@@ -12,6 +12,7 @@ import { ViewportService } from '../../provider/viewport.service';
 import { DraftContainerComponent } from '../draftcontainer/draftcontainer.component';
 import { CdkDragMove, CdkDragStart } from '@angular/cdk/drag-drop';
 import { MatMenuTrigger } from '@angular/material/menu';
+import { ConnectionComponent } from '../connection/connection.component';
 
 
 @Component({
@@ -198,11 +199,37 @@ export class SubdraftComponent implements OnInit {
 
   }
 
+  updateConnectionStyling(){
+
+      //remove the selected class for all connections
+      let cxns = this.tree.getConnections();
+      for(let cxn of cxns){
+        if(cxn !== null){
+          cxn.updateConnectionStyling(false);
+        }
+      }
+
+      const outputs = this.tree.getOutputs(this.id);
+
+      //add the class selected to any of the connections going into and out of this node
+      let ios = outputs.concat(this.tree.getInputs(this.id));
+      for(let io of ios){
+        let cxn = <ConnectionComponent> this.tree.getComponent(io);
+        if(cxn !== null) cxn.updateConnectionStyling(true)
+      }
+
+  }
+
+
+
 
   toggleMultiSelection(e: any){
 
     // console.log("TOGGLE MULTI")
     // this.onFocus.emit(this.id);
+    this.updateConnectionStyling();
+        this.vs.setViewer(this.id);
+
 
     if(e.shiftKey){
       this.multiselect.toggleSelection(this.id, this.topleft);

--- a/src/app/mixer/palette/subdraft/subdraft.component.ts
+++ b/src/app/mixer/palette/subdraft/subdraft.component.ts
@@ -177,7 +177,7 @@ export class SubdraftComponent implements OnInit {
 
  
 
-  nameFocusOut(){
+  nameChange(){
     this.onNameChange.emit(this.id);
   }
 

--- a/src/assets/json/op_classifications.json
+++ b/src/assets/json/op_classifications.json
@@ -95,7 +95,8 @@
                 "overlay",
                 "mask",
                 "cutout",
-                "diff"
+                "diff",
+                "selector"
             ]
         },
         {

--- a/src/assets/json/op_classifications.json
+++ b/src/assets/json/op_classifications.json
@@ -83,6 +83,7 @@
             "color":"#00A2C7",
             "description": "Describes operations that split apart a single input draft into multiple outputs according to some criteria.",
             "op_names":[
+                "analyzesystem",
                 "deinterlace"
             ]
         },

--- a/src/assets/json/op_descriptions.json
+++ b/src/assets/json/op_descriptions.json
@@ -248,6 +248,13 @@
             "application": "Can be used to generated pointed threadings and treadlings" 
         },
         {
+            "name":"selector",
+            "displayname": "selector",
+            "tags": ["advanced"],
+            "description": "allows the user to switch between the connected inputs by changing the parameter number.",
+            "application": "To control a large number of inputs at once rather than having to add and remove individual connections" 
+        },
+        {
             "name":"fill",
             "displayname": "fill",
             "tags": ["advanced"],

--- a/src/assets/json/op_descriptions.json
+++ b/src/assets/json/op_descriptions.json
@@ -142,6 +142,13 @@
             "application": "Not sure, but perhaps it is interesting for the purposes of analyzing a draft structure or splitting apart layered drafts into their component layer patterns" 
         },
         {
+            "name":"analyzesystem",
+            "displayname": "analyze systems",
+            "tags": ["advanced"],
+            "description": "--",
+            "application": "--" 
+        },
+        {
             "name":"interlacewarps",
             "displayname": "interlace warps",
             "tags": ["advanced"],


### PR DESCRIPTION
## Added "Selector" Operations
closes #252 by creating the "selector" operation to the "compute" category that allows you to quickly change the input that is funneled to the outlet. This can be used as a proxy for places where you might want one draft to feed to multiple other operations while still being able to change it quickly without reconnecting a million things! Thanks Teresa! 
<img width="679" height="549" alt="Screenshot 2025-08-02 at 4 01 36 PM" src="https://github.com/user-attachments/assets/1d8fd0b8-9cf7-484c-9e6f-81c6435673f9" />

## Highlighting Connections on Selected Operation or Draft
closes #256 and streamlines connector rendering. Now, when you have a single operation selected, you will also see the incoming and outgoing connections turn to bold. I also updated the connection rendering so it's a bit bolder. This is especially handy when working with big and complicated workspaces. Thanks Teresa.
<img width="763" height="620" alt="Screenshot 2025-08-02 at 5 36 48 PM" src="https://github.com/user-attachments/assets/7ea33baf-1c91-4feb-9858-c73077a3c39c" />

## Changing Warp-Facing and Weft Facing. 
closes #237 by changing warp-facing and weft-facing to A and B. Thanks Bhakti. 

## Added "Analyze Systems" Operation
I added this to the "dissect" section. It lets you take a draft that uses system information and then creates a new draft based on the systems you would like to view or select. Might be good for debugging. 
<img width="581" height="642" alt="Screenshot 2025-08-02 at 5 35 37 PM" src="https://github.com/user-attachments/assets/0c03560a-a8a6-440b-a573-fbeea89c5c0d" />

## Added Better Function and Support for Naming Drafts
Since 4.0, giving the drafts names has been pretty buggy. I fixed it and added a new "edit" button on the drafts so that you can click it to dynamically add a name. I also updated it so that the operations automatically generate a name if another one i s not provided. 
<img width="308" height="240" alt="Screenshot 2025-08-02 at 5 37 54 PM" src="https://github.com/user-attachments/assets/bb498907-5207-41fb-aecf-2d6e4d07b3b6" />
<img width="690" height="381" alt="Screenshot 2025-08-02 at 5 37 49 PM" src="https://github.com/user-attachments/assets/2360c106-412c-4987-8db6-60008c016fe4" />

